### PR TITLE
Cache 404 responses

### DIFF
--- a/error.go
+++ b/error.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	errNotFound       = statusErr(http.StatusNotFound) //nolint:unused
+	errNotFound       = statusErr(http.StatusNotFound)
 	errBadRequest     = statusErr(http.StatusBadRequest)
 	errNotImplemented = statusErr(http.StatusNotImplemented)
 

--- a/handler.go
+++ b/handler.go
@@ -123,9 +123,11 @@ func (h *handler) bulkBook(w http.ResponseWriter, r *http.Request) {
 		go func(foreignBookID int64) {
 			defer wg.Done()
 
-			b, err := h.ctrl.getBook(ctx, foreignBookID)
+			b, err := h.ctrl.GetBook(ctx, foreignBookID)
 			if err != nil {
-				log(ctx).Warn("getting book", "err", err)
+				if !errors.Is(err, errNotFound) {
+					log(ctx).Warn("getting book", "err", err, "bookID", foreignBookID)
+				}
 				return // Ignore the error.
 			}
 


### PR DESCRIPTION
Store a placeholder in the cache for 404 responses so we don't continuously re-query for missing data.