### PR TITLE
Disambiguate duplicate titles

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -502,7 +502,7 @@ func (c *controller) ensureWorks(ctx context.Context, authorID int64, workIDs ..
 	ratingSum := int64(0)
 	ratingCount := int64(0)
 	for _, w := range author.Works {
-		titles[w.Title] += 1
+		titles[w.Title]++
 		for _, b := range w.Books {
 			ratingCount += b.RatingCount
 			ratingSum += b.RatingSum

--- a/controller.go
+++ b/controller.go
@@ -493,12 +493,16 @@ func (c *controller) ensureWorks(ctx context.Context, authorID int64, workIDs ..
 
 	author.Series = []seriesResource{}
 
+	// Keep track of any duplicated titles so we can disambiguate them with subtitles.
+	titles := map[string]int{}
+
 	// Collect series and merge link items so each SeriesResource collects all
 	// of the linked works.
 	series := map[int64]*seriesResource{}
 	ratingSum := int64(0)
 	ratingCount := int64(0)
 	for _, w := range author.Works {
+		titles[w.Title] += 1
 		for _, b := range w.Books {
 			ratingCount += b.RatingCount
 			ratingSum += b.RatingSum
@@ -509,6 +513,22 @@ func (c *controller) ensureWorks(ctx context.Context, authorID int64, workIDs ..
 				continue
 			}
 			series[s.ForeignID] = &s
+		}
+	}
+	// Disambiguate works which share the same title by including subtitles.
+	for idx := range author.Works {
+		if titles[author.Works[idx].Title] <= 1 {
+			continue
+		}
+		if author.Works[idx].FullTitle == "" {
+			continue
+		}
+		author.Works[idx].Title = author.Works[idx].FullTitle
+		for bidx := range author.Works[idx].Books {
+			if author.Works[idx].Books[bidx].FullTitle == "" {
+				continue
+			}
+			author.Works[idx].Books[bidx].Title = author.Works[idx].Books[bidx].FullTitle
 		}
 	}
 	for _, s := range series {

--- a/controller_test.go
+++ b/controller_test.go
@@ -188,7 +188,8 @@ func TestSubtitles(t *testing.T) {
 	c := gomock.NewController(t)
 	getter := internal.NewMockgetter(c)
 
-	workDupe1 := workResource{ForeignID: 1,
+	workDupe1 := workResource{
+		ForeignID: 1,
 		Title:     "Foo",
 		FullTitle: "Foo: First Work",
 		Books: []bookResource{
@@ -197,7 +198,8 @@ func TestSubtitles(t *testing.T) {
 		},
 	}
 
-	workDupe2 := workResource{ForeignID: 2,
+	workDupe2 := workResource{
+		ForeignID: 2,
 		Title:     "Foo",
 		FullTitle: "Foo: Second Work",
 		Books: []bookResource{
@@ -206,7 +208,8 @@ func TestSubtitles(t *testing.T) {
 		},
 	}
 
-	workUnique := workResource{ForeignID: 3,
+	workUnique := workResource{
+		ForeignID: 3,
 		Title:     "Bar",
 		FullTitle: "Bar: Not Foo",
 		Books: []bookResource{

--- a/controller_test.go
+++ b/controller_test.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"iter"
 	"testing"
 	"time"
 
@@ -176,4 +177,116 @@ func TestEnsureMissing(t *testing.T) {
 
 	err = ctrl.ensureWorks(ctx, authorID, workID)
 	assert.ErrorIs(t, err, errNotFound)
+}
+
+func TestSubtitles(t *testing.T) {
+	// Subtitles (i.e. FullTitle) are used in situations where multiple works share the same primary title.
+
+	t.Parallel()
+
+	ctx := context.Background()
+	c := gomock.NewController(t)
+	getter := internal.NewMockgetter(c)
+
+	workDupe1 := workResource{ForeignID: 1,
+		Title:     "Foo",
+		FullTitle: "Foo: First Work",
+		Books: []bookResource{
+			{ForeignID: 1, Title: "Foo", FullTitle: "Foo: First Edition"},
+			{ForeignID: 2, Title: "Foo", FullTitle: ""},
+		},
+	}
+
+	workDupe2 := workResource{ForeignID: 2,
+		Title:     "Foo",
+		FullTitle: "Foo: Second Work",
+		Books: []bookResource{
+			{ForeignID: 10, Title: "Foo", FullTitle: "Foo: Second Edition"},
+			{ForeignID: 20, Title: "Foo", FullTitle: ""},
+		},
+	}
+
+	workUnique := workResource{ForeignID: 3,
+		Title:     "Bar",
+		FullTitle: "Bar: Not Foo",
+		Books: []bookResource{
+			{ForeignID: 10, Title: "Bar", FullTitle: "Bar: Not Foo"},
+			{ForeignID: 20, Title: "Bar", FullTitle: ""},
+		},
+	}
+
+	author := authorResource{ForeignID: 1000, Works: []workResource{workDupe1, workDupe2, workUnique}}
+
+	workDupe1.Authors = []authorResource{author}
+	workDupe2.Authors = []authorResource{author}
+	workUnique.Authors = []authorResource{author}
+
+	initialAuthorBytes, err := json.Marshal(author)
+	require.NoError(t, err)
+	initialWorkDupe1Bytes, err := json.Marshal(workDupe1)
+	require.NoError(t, err)
+	initialWorkDupe2Bytes, err := json.Marshal(workDupe2)
+	require.NoError(t, err)
+	initialWorkUniqueBytes, err := json.Marshal(workUnique)
+	require.NoError(t, err)
+
+	cache := &layeredcache{wrapped: []cache.SetterCacheInterface[[]byte]{newMemory()}}
+
+	ctrl, err := newController(cache, getter)
+	require.NoError(t, err)
+
+	getter.EXPECT().GetAuthor(gomock.Any(), author.ForeignID).DoAndReturn(func(ctx context.Context, authorID int64) ([]byte, error) {
+		cachedBytes, ok := ctrl.cache.Get(ctx, authorKey(authorID))
+		if ok {
+			return cachedBytes, nil
+		}
+		return initialAuthorBytes, nil
+	}).AnyTimes()
+
+	getter.EXPECT().GetWork(gomock.Any(), workDupe1.ForeignID).DoAndReturn(func(ctx context.Context, workID int64) ([]byte, int64, error) {
+		cachedBytes, ok := ctrl.cache.Get(ctx, workKey(workID))
+		if ok {
+			return cachedBytes, 0, nil
+		}
+		return initialWorkDupe1Bytes, author.ForeignID, nil
+	}).AnyTimes()
+
+	getter.EXPECT().GetWork(gomock.Any(), workDupe2.ForeignID).DoAndReturn(func(ctx context.Context, workID int64) ([]byte, int64, error) {
+		cachedBytes, ok := ctrl.cache.Get(ctx, workKey(workID))
+		if ok {
+			return cachedBytes, 0, nil
+		}
+		return initialWorkDupe2Bytes, author.ForeignID, nil
+	}).AnyTimes()
+
+	getter.EXPECT().GetWork(gomock.Any(), workUnique.ForeignID).DoAndReturn(func(ctx context.Context, workID int64) ([]byte, int64, error) {
+		cachedBytes, ok := ctrl.cache.Get(ctx, workKey(workID))
+		if ok {
+			return cachedBytes, 0, nil
+		}
+		return initialWorkUniqueBytes, author.ForeignID, nil
+	}).AnyTimes()
+
+	getter.EXPECT().GetAuthorBooks(gomock.Any(), author.ForeignID).Return(iter.Seq[int64](nil))
+
+	err = ctrl.ensureWorks(ctx, author.ForeignID, workDupe1.ForeignID, workDupe2.ForeignID, workUnique.ForeignID)
+	require.NoError(t, err)
+
+	authorBytes, err := ctrl.GetAuthor(ctx, author.ForeignID)
+	require.NoError(t, err)
+
+	require.NoError(t, json.Unmarshal(authorBytes, &author))
+
+	assert.Equal(t, "Foo: First Work", author.Works[0].Title)
+	assert.Equal(t, "Foo: Second Work", author.Works[1].Title)
+	assert.Equal(t, "Bar", author.Works[2].Title)
+
+	assert.Equal(t, "Foo: First Edition", author.Works[0].Books[0].Title)
+	assert.Equal(t, "Foo", author.Works[0].Books[1].Title)
+
+	assert.Equal(t, "Foo: Second Edition", author.Works[1].Books[0].Title)
+	assert.Equal(t, "Foo", author.Works[1].Books[1].Title)
+
+	assert.Equal(t, "Bar", author.Works[2].Books[0].Title)
+	assert.Equal(t, "Bar", author.Works[2].Books[1].Title)
 }

--- a/resources.go
+++ b/resources.go
@@ -12,6 +12,7 @@ type bulkBookResource struct {
 type workResource struct {
 	ForeignID    int64    `json:"ForeignId"`
 	Title        string   `json:"Title"`
+	FullTitle    string   `json:"FullTitle"`
 	URL          string   `json:"Url"`
 	ReleaseDate  string   `json:"ReleaseDate,omitempty"`
 	Genres       []string `json:"Genres"`
@@ -49,6 +50,7 @@ type bookResource struct {
 	Description        string  `json:"Description"`
 	Isbn13             string  `json:"Isbn13,omitempty"`
 	Title              string  `json:"Title"`
+	FullTitle          string  `json:"FullTitle"`
 	Language           string  `json:"Language"`
 	Format             string  `json:"Format"`
 	EditionInformation string  `json:"EditionInformation"`


### PR DESCRIPTION
This starts using full titles (e.g. including subtitles) in cases where an author has several works with the same primary title. We continue to only use the primary title when it's unambiguous.

I only make this change on the author resource, but technically I should also update corresponding book/work entries. I'm avoiding that for now because I want to avoid loops (author updated → work updated → author updated etc.) and because the author resource tends to be the source of truth in the UI. This leaves the door open for some inconsistent behavior when an individual work is refreshed, but it should self-resolve the next time the author is refreshed.

This fixes https://github.com/blampe/rreading-glasses/issues/35 and https://github.com/blampe/rreading-glasses/issues/45 but it will take up to a week to propagate to users. This is because
1. The metadata provider needs to start populating `FullTitle`.
2. Author cache entries to be refreshed.
3. Clients need to refresh author metadata.