### PR TITLE
Only compress data at rest

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -1,11 +1,9 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"runtime/debug"
 	"sync/atomic"
@@ -15,7 +13,6 @@ import (
 	"github.com/eko/gocache/lib/v4/cache"
 	"github.com/eko/gocache/lib/v4/store"
 	memory "github.com/eko/gocache/store/ristretto/v4"
-	"github.com/klauspost/compress/gzip"
 )
 
 // layeredcache implements a simple tiered cache. In practice we use an
@@ -33,19 +30,19 @@ type layeredcache struct {
 }
 
 func (c *layeredcache) GetWithTTL(ctx context.Context, key string) ([]byte, time.Duration, bool) {
-	var compressed []byte
+	var val []byte
 	var ttl time.Duration
 	var err error
 
 	for idx, cc := range c.wrapped {
-		compressed, ttl, err = cc.GetWithTTL(ctx, key)
+		val, ttl, err = cc.GetWithTTL(ctx, key)
 		if err != nil {
 			// Percolate the value back up if we eventually find it.
 			defer func(cc cache.SetterCacheInterface[[]byte]) {
-				if compressed == nil {
+				if val == nil {
 					return
 				}
-				err = cc.Set(ctx, key, compressed, store.WithExpiration(ttl), store.WithSynchronousSet())
+				err = cc.Set(ctx, key, val, store.WithExpiration(ttl), store.WithSynchronousSet())
 				if err != nil {
 					log(ctx).Warn("problem caching", "key", key, "layer", idx)
 				}
@@ -53,34 +50,15 @@ func (c *layeredcache) GetWithTTL(ctx context.Context, key string) ([]byte, time
 			continue
 		}
 
-		zr, err := gzip.NewReader(bytes.NewReader(compressed))
-		if err != nil && !errors.Is(err, io.EOF) {
-			log(ctx).Warn("problem unzipping", "err", err)
-			// Ignore this cached value and try the next.
-			compressed = nil
-			continue
-		}
-
-		// TODO: The client doesn't support gzip content-encoding, which is too
-		// bade because we could just return compressed bytes as-is.
-		uncompressed := bytes.Buffer{}
-
-		_, err = io.Copy(&uncompressed, zr)
-		if err != nil && !errors.Is(err, io.EOF) {
-			log(ctx).Warn("problem decompressing", "err", err)
-		}
-		if err := zr.Close(); err != nil {
-			log(ctx).Warn("problem closing zip write", "err", err)
-		}
-
 		_ = c.hits.Add(1)
 		log(ctx).LogAttrs(ctx, slog.LevelDebug, "cache hit",
 			slog.Int("layer", idx),
 			slog.String("key", key),
-			slog.Int("size", len(compressed)),
+			slog.Int("size", len(val)),
 			slog.Duration("ttl", ttl),
 		)
-		return uncompressed.Bytes(), ttl, true
+
+		return val, ttl, true
 	}
 
 	_ = c.misses.Add(1)
@@ -112,28 +90,14 @@ func (c *layeredcache) Set(ctx context.Context, key string, val []byte, ttl time
 		return
 	}
 
-	compressed, err := compress(val)
-	if err != nil && !errors.Is(err, io.EOF) {
-		log(ctx).Warn("problem compressing", "err", err)
-		return
-	}
-
 	// TODO: We can offload the DB write to a background goroutine to speed
 	// things up.
 	for idx, cc := range c.wrapped {
-		err := cc.Set(ctx, key, compressed, store.WithExpiration(ttl), store.WithSynchronousSet())
+		err := cc.Set(ctx, key, val, store.WithExpiration(ttl), store.WithSynchronousSet())
 		if err != nil {
 			log(ctx).Warn("problem setting cache", "err", err, "layer", idx)
 		}
 	}
-}
-
-func compress(val []byte) ([]byte, error) {
-	compressed := bytes.Buffer{}
-	zw := gzip.NewWriter(&compressed)
-	_, err := zw.Write(val)
-	err = errors.Join(err, zw.Close())
-	return compressed.Bytes(), err
 }
 
 func newCache(ctx context.Context, dsn string) (*layeredcache, error) {

--- a/cache_test.go
+++ b/cache_test.go
@@ -28,11 +28,8 @@ func TestCache(t *testing.T) {
 		key := "c0-miss"
 		val := []byte(key)
 
-		valCompressed, err := compress(val)
-		require.NoError(t, err)
-
 		// Only c1 starts with the entry,
-		err = c1.Set(ctx, key, valCompressed, store.WithExpiration(time.Hour), store.WithSynchronousSet())
+		err := c1.Set(ctx, key, val, store.WithExpiration(time.Hour), store.WithSynchronousSet())
 		require.NoError(t, err)
 
 		out, ok := l.Get(ctx, key)
@@ -42,7 +39,7 @@ func TestCache(t *testing.T) {
 		// c0 now has it.
 		out, ttl, err := c0.GetWithTTL(ctx, key)
 		assert.NoError(t, err)
-		assert.Equal(t, valCompressed, out)
+		assert.Equal(t, val, out)
 		assert.Greater(t, ttl, time.Minute)
 	})
 
@@ -50,18 +47,15 @@ func TestCache(t *testing.T) {
 		key := "set-get"
 		val := []byte(key)
 
-		valCompressed, err := compress(val)
-		require.NoError(t, err)
-
 		l.Set(ctx, key, val, time.Hour)
 
 		out, err := c0.Get(ctx, key)
 		assert.NoError(t, err)
-		assert.Equal(t, valCompressed, out)
+		assert.Equal(t, val, out)
 
 		out, err = c1.Get(ctx, key)
 		assert.NoError(t, err)
-		assert.Equal(t, valCompressed, out)
+		assert.Equal(t, val, out)
 
 		out, ok := l.Get(ctx, key)
 		assert.True(t, ok)


### PR DESCRIPTION
We don't gain much by storing compressed cache values in memory, in fact we end up allocating a lot of slices to decompress things. PG hits are fast enough, so the size of our in-memory set isn't too important. (It's currently around ~28k items for ~1.8G RAM.)  

This change introduces a buffer pool to help reduce GC churn. This is a sufficient fix, but we also push compression down to only the PG layer. This will make #28 easier to reason about.