### PR TITLE
Parallelize visit

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -263,7 +263,7 @@ func (qb *queryBuilder) add(query string, vars map[string]interface{}) (id strin
 		}
 
 		// Visit the AST to rename vars and alias fields
-		visitor.Visit(opDef, &visitor.VisitorOptions{
+		opts := visitor.VisitInParallel(&visitor.VisitorOptions{
 			Enter: func(p visitor.VisitFuncParams) (string, interface{}) {
 				switch node := p.Node.(type) {
 				case *ast.VariableDefinition:
@@ -284,7 +284,8 @@ func (qb *queryBuilder) add(query string, vars map[string]interface{}) (id strin
 				}
 				return visitor.ActionNoChange, nil
 			},
-		}, nil)
+		})
+		visitor.Visit(opDef, opts, nil)
 
 		qb.fields++
 


### PR DESCRIPTION
This is low-hanging fruit to parallelize the Visit call, which is fairly expensive.

We only have a handful of these queries, so ideally we would cache the parsed ASTs but that will take a little more work.