### PR TITLE
Purge invalid cache entries

### DIFF
--- a/internal/controller.go
+++ b/internal/controller.go
@@ -409,8 +409,9 @@ func (c *Controller) ensureEditions(ctx context.Context, workID int64, bookIDs .
 	var work workResource
 	err = json.Unmarshal(workBytes, &work)
 	if err != nil {
-		Log(ctx).Debug("problem unmarshaling work", "err", err)
-		return nil
+		Log(ctx).Debug("problem unmarshaling work", "err", err, "workID", workID)
+		_ = c.cache.Delete(ctx, WorkKey(workID))
+		return err
 	}
 
 	Log(ctx).Debug("ensuring work-edition edges", "workID", workID, "bookIDs", bookIDs)
@@ -431,7 +432,8 @@ func (c *Controller) ensureEditions(ctx context.Context, workID int64, bookIDs .
 		var w workResource
 		err = json.Unmarshal(workBytes, &w)
 		if err != nil {
-			Log(ctx).Warn("problem unmarshaling work", "err", err)
+			Log(ctx).Warn("problem unmarshaling book", "err", err, "bookID", bookID)
+			_ = c.cache.Delete(ctx, BookKey(bookID))
 			continue
 		}
 
@@ -493,8 +495,9 @@ func (c *Controller) ensureWorks(ctx context.Context, authorID int64, workIDs ..
 	var author AuthorResource
 	err = json.Unmarshal(a, &author)
 	if err != nil {
-		Log(ctx).Debug("problem unmarshaling author", "err", err)
-		return nil
+		Log(ctx).Debug("problem unmarshaling author", "err", err, "authorID", authorID)
+		_ = c.cache.Delete(ctx, AuthorKey(authorID))
+		return err
 	}
 
 	Log(ctx).Debug("ensuring author-work edges", "authorID", authorID, "workID", workIDs)
@@ -515,7 +518,8 @@ func (c *Controller) ensureWorks(ctx context.Context, authorID int64, workIDs ..
 		var work workResource
 		err = json.Unmarshal(workBytes, &work)
 		if err != nil {
-			Log(ctx).Warn("problem unmarshaling work", "err", err)
+			Log(ctx).Warn("problem unmarshaling work", "err", err, "workID", workID)
+			_ = c.cache.Delete(ctx, WorkKey(workID))
 			continue
 		}
 

--- a/internal/error.go
+++ b/internal/error.go
@@ -9,6 +9,7 @@ import (
 var (
 	errNotFound   = statusErr(http.StatusNotFound)
 	errBadRequest = statusErr(http.StatusBadRequest)
+	errTryAgain   = statusErr(http.StatusTooManyRequests) // Will be retried.
 
 	errMissingIDs = errors.Join(fmt.Errorf(`missing "ids"`), errBadRequest)
 )

--- a/internal/graphql.go
+++ b/internal/graphql.go
@@ -89,7 +89,7 @@ func (c *batchedgqlclient) flush(ctx context.Context) {
 
 		err := c.wrapped.MakeRequest(ctx, req, resp)
 		if err != nil {
-			Log(ctx).Warn("batched query error", "count", c.qb.fields, "err", err)
+			Log(ctx).Warn("batched query error", "count", c.qb.fields, "err", err, "resp.Errors", resp.Errors)
 			for _, sub := range subscriptions {
 				sub.respC <- err
 			}


### PR DESCRIPTION
There were a few ~minutes before #87 was live where cached values could become corrupted due to a buffer pooling bug. The app will try to load these entries, fail, and return an error to the user. A refresh isn't attempted until the TTL expires, and even then the refresh will never succeed for authors.

Instead, when we encounter these malformed entries, we should just remove them from the cache to force a subsequent refresh.

Fixes #101