### PR TITLE
Ignore deserialization errors on author refresh

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,11 +87,11 @@ func (b *Bust) Run() error {
 
 	for _, w := range author.Works {
 		for _, b := range w.Books {
-			err = errors.Join(err, cache.Delete(ctx, internal.BookKey(b.ForeignID)))
+			err = errors.Join(err, cache.Expire(ctx, internal.BookKey(b.ForeignID)))
 		}
-		err = errors.Join(err, cache.Delete(ctx, internal.WorkKey(w.ForeignID)))
+		err = errors.Join(err, cache.Expire(ctx, internal.WorkKey(w.ForeignID)))
 	}
-	err = errors.Join(err, cache.Delete(ctx, internal.AuthorKey(author.ForeignID)))
+	err = errors.Join(err, cache.Expire(ctx, internal.AuthorKey(author.ForeignID)))
 
 	return err
 }

--- a/internal/cache.go
+++ b/internal/cache.go
@@ -68,8 +68,9 @@ func (c *LayeredCache) Get(ctx context.Context, key string) ([]byte, bool) {
 	return val, ok
 }
 
-// Delete removes a key from all layers of the cache.
-func (c *LayeredCache) Delete(ctx context.Context, key string) error {
+// Expire expires a key from all layers of the cache. This removes it from
+// memory but keeps data persisted in Postgres without a TTL.
+func (c *LayeredCache) Expire(ctx context.Context, key string) error {
 	var err error
 	for _, cc := range c.wrapped {
 		err = errors.Join(cc.Delete(ctx, key))

--- a/internal/controller.go
+++ b/internal/controller.go
@@ -410,7 +410,7 @@ func (c *Controller) ensureEditions(ctx context.Context, workID int64, bookIDs .
 	err = json.Unmarshal(workBytes, &work)
 	if err != nil {
 		Log(ctx).Debug("problem unmarshaling work", "err", err, "workID", workID)
-		_ = c.cache.Delete(ctx, WorkKey(workID))
+		_ = c.cache.Expire(ctx, WorkKey(workID))
 		return err
 	}
 
@@ -433,7 +433,7 @@ func (c *Controller) ensureEditions(ctx context.Context, workID int64, bookIDs .
 		err = json.Unmarshal(workBytes, &w)
 		if err != nil {
 			Log(ctx).Warn("problem unmarshaling book", "err", err, "bookID", bookID)
-			_ = c.cache.Delete(ctx, BookKey(bookID))
+			_ = c.cache.Expire(ctx, BookKey(bookID))
 			continue
 		}
 
@@ -496,7 +496,7 @@ func (c *Controller) ensureWorks(ctx context.Context, authorID int64, workIDs ..
 	err = json.Unmarshal(a, &author)
 	if err != nil {
 		Log(ctx).Debug("problem unmarshaling author", "err", err, "authorID", authorID)
-		_ = c.cache.Delete(ctx, AuthorKey(authorID))
+		_ = c.cache.Expire(ctx, AuthorKey(authorID))
 		return err
 	}
 
@@ -519,7 +519,7 @@ func (c *Controller) ensureWorks(ctx context.Context, authorID int64, workIDs ..
 		err = json.Unmarshal(workBytes, &work)
 		if err != nil {
 			Log(ctx).Warn("problem unmarshaling work", "err", err, "workID", workID)
-			_ = c.cache.Delete(ctx, WorkKey(workID))
+			_ = c.cache.Expire(ctx, WorkKey(workID))
 			continue
 		}
 

--- a/internal/controller_test.go
+++ b/internal/controller_test.go
@@ -127,7 +127,7 @@ func TestIncrementalEnsure(t *testing.T) {
 	assert.Equal(t, frenchEdition.ForeignID, author.Works[0].Books[1].ForeignID)
 
 	// Force a cache miss to re-trigger ensure.
-	_ = ctrl.cache.Delete(ctx, BookKey(frenchEdition.ForeignID))
+	_ = ctrl.cache.Expire(ctx, BookKey(frenchEdition.ForeignID))
 	_, _ = ctrl.GetBook(ctx, frenchEdition.ForeignID)
 
 	time.Sleep(100 * time.Millisecond) // Wait for the ensure goroutine update things.
@@ -143,7 +143,7 @@ func TestIncrementalEnsure(t *testing.T) {
 	assert.Len(t, author.Works[0].Books, 2)
 
 	// Force an author cache miss to re-trigger ensure.
-	_ = ctrl.cache.Delete(ctx, AuthorKey(author.ForeignID))
+	_ = ctrl.cache.Expire(ctx, AuthorKey(author.ForeignID))
 	_, _ = ctrl.GetAuthor(ctx, author.ForeignID)
 
 	time.Sleep(100 * time.Millisecond) // Wait for the ensure goroutine update things.

--- a/internal/handler.go
+++ b/internal/handler.go
@@ -197,7 +197,7 @@ func (h *Handler) getWorkID(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if r.Method == "DELETE" {
-		_ = h.ctrl.cache.Delete(r.Context(), WorkKey(workID))
+		_ = h.ctrl.cache.Expire(r.Context(), WorkKey(workID))
 		w.WriteHeader(http.StatusOK)
 		return
 	}
@@ -251,7 +251,7 @@ func (h *Handler) getBookID(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if r.Method == "DELETE" {
-		_ = h.ctrl.cache.Delete(r.Context(), BookKey(bookID))
+		_ = h.ctrl.cache.Expire(r.Context(), BookKey(bookID))
 		w.WriteHeader(http.StatusOK)
 		return
 	}
@@ -296,7 +296,7 @@ func (h *Handler) getAuthorID(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if r.Method == "DELETE" {
-		_ = h.ctrl.cache.Delete(r.Context(), AuthorKey(authorID))
+		_ = h.ctrl.cache.Expire(r.Context(), AuthorKey(authorID))
 		go func() { _, _ = h.ctrl.GetAuthor(context.Background(), authorID) }() // Kick off a refresh.
 		w.WriteHeader(http.StatusOK)
 		return

--- a/internal/postgres_test.go
+++ b/internal/postgres_test.go
@@ -112,7 +112,7 @@ func TestPostgresCache(t *testing.T) {
 
 	t.Cleanup(func() {
 		for i := range n {
-			_ = cache.Delete(ctx, fmt.Sprint(i))
+			_ = cache.Expire(ctx, fmt.Sprint(i))
 		}
 	})
 }


### PR DESCRIPTION
Data lives in PG forever now (#92), so Delete doesn't do what it says. Rename it to Expire.

Actually fixes #101 by ignoring the unmarshal error on author refresh when we sniff the expired data. It's ok to ignore this data if it's invalid.