### PR TITLE
Eventually retry 404s

### DIFF
--- a/internal/hardcover.go
+++ b/internal/hardcover.go
@@ -38,7 +38,7 @@ func NewHardcoverGetter(cache *LayeredCache, gql graphql.Client, upstream *http.
 // return that.
 func (g *HCGetter) GetWork(ctx context.Context, grWorkID int64) ([]byte, int64, error) {
 	workBytes, ttl, ok := g.cache.GetWithTTL(ctx, WorkKey(grWorkID))
-	if ok && ttl > _workTTL {
+	if ok && ttl > 0 {
 		return workBytes, 0, nil
 	}
 
@@ -256,7 +256,7 @@ func (g *HCGetter) GetBook(ctx context.Context, grBookID int64) ([]byte, int64, 
 
 	// If a work isn't already cached with this ID, write one using our edition as a starting point.
 	if _, ok := g.cache.Get(ctx, WorkKey(workRsc.ForeignID)); !ok {
-		g.cache.Set(ctx, WorkKey(workRsc.ForeignID), out, 2*_workTTL)
+		g.cache.Set(ctx, WorkKey(workRsc.ForeignID), out, _workTTL)
 	}
 
 	return out, workRsc.ForeignID, authorRsc.ForeignID, nil


### PR DESCRIPTION
We have a bug where if we ever store a `_missing` sentinel we'll never refresh the cache entry. This fixes that.

We also no longer need to store things with the confusing 2x TTL. That was to ensure we still had data available after TTL expiration, but we're always returning stale data now so it's a non-issue.

We also start fuzzing TTLs a bit to spread out load.