### PR TITLE
Repair broken sort invariants

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ lint:
 
 .PHONY: test
 test:
-	go test -v -count=1 -coverpkg=./... ./...
+	go test -v -count=1 -race -coverpkg=./... -covermode=atomic -coverprofile=coverage.txt ./...
 
 .PHONY: release-hc
 release-hc:

--- a/cmd/rggr/main.go
+++ b/cmd/rggr/main.go
@@ -130,7 +130,7 @@ func (s *server) Run() error {
 		_ = server.Shutdown(ctx)
 	}()
 
-	ctrl.Run(ctx)
+	ctrl.Run(ctx, 2*time.Second)
 
 	slog.Info("au revoir!")
 

--- a/cmd/rghc/main.go
+++ b/cmd/rghc/main.go
@@ -115,7 +115,7 @@ func (s *server) Run() error {
 		ctrl.Shutdown(ctx)
 	}()
 
-	ctrl.Run(ctx)
+	ctrl.Run(ctx, 2*time.Second)
 
 	slog.Info("au revoir!")
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,3 +2,4 @@ ignore:
   - gr/generated.go
   - hardcover/generated.go
   - hardcover/mock.go
+  - internal/mock.go

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+ignore:
+  - gr/generated.go
+  - hardcover/generated.go
+  - hardcover/mock.go

--- a/internal/controller.go
+++ b/internal/controller.go
@@ -57,10 +57,8 @@ type Controller struct {
 	getter getter             // Core GetBook/GetAuthor/GetWork implementation.
 	group  singleflight.Group // Coalesce lookups for the same key.
 
-	ensureC chan edge      // Serializes edge updates.
-	ensureG errgroup.Group // Limits how many authors/works we sync in the background.
-
-	// cf       *cloudflare.API // TODO: CDN invalidation.
+	denormC  chan edge      // Serializes denormalization updates.
+	refreshG errgroup.Group // Limits how many authors/works we sync in the background.
 }
 
 // getter allows alternative implementations of the core logic to be injected.
@@ -129,10 +127,10 @@ func NewController(cache *LayeredCache, getter getter) (*Controller, error) {
 		cache:  cache,
 		getter: getter,
 
-		ensureC: make(chan edge),
+		denormC: make(chan edge),
 	}
 
-	c.ensureG.SetLimit(10)
+	c.refreshG.SetLimit(10)
 
 	return c, nil
 }
@@ -191,7 +189,7 @@ func (c *Controller) getBook(ctx context.Context, bookID int64) ([]byte, error) 
 	if workID > 0 {
 		// Ensure the edition/book is included with the work, but don't block the response.
 		go func() {
-			c.ensureG.Go(func() error {
+			c.refreshG.Go(func() error {
 				ctx := context.Background()
 
 				defer func() {
@@ -200,7 +198,7 @@ func (c *Controller) getBook(ctx context.Context, bookID int64) ([]byte, error) 
 					}
 				}()
 
-				c.ensureC <- edge{kind: workEdge, parentID: workID, childIDs: []int64{bookID}}
+				c.denormC <- edge{kind: workEdge, parentID: workID, childIDs: []int64{bookID}}
 
 				return nil
 			})
@@ -234,7 +232,7 @@ func (c *Controller) getWork(ctx context.Context, workID int64) ([]byte, error) 
 
 	// Ensuring relationships doesn't block.
 	go func() {
-		c.ensureG.Go(func() error {
+		c.refreshG.Go(func() error {
 			ctx := context.Background()
 
 			defer func() {
@@ -251,11 +249,11 @@ func (c *Controller) getWork(ctx context.Context, workID int64) ([]byte, error) 
 			for _, b := range cached.Books {
 				cachedBookIDs = append(cachedBookIDs, b.ForeignID)
 			}
-			c.ensureC <- edge{kind: workEdge, parentID: workID, childIDs: cachedBookIDs}
+			c.denormC <- edge{kind: workEdge, parentID: workID, childIDs: cachedBookIDs}
 
 			if authorID > 0 {
 				// Ensure the work belongs to its author.
-				c.ensureC <- edge{kind: authorEdge, parentID: authorID, childIDs: []int64{workID}}
+				c.denormC <- edge{kind: authorEdge, parentID: authorID, childIDs: []int64{workID}}
 			}
 
 			return nil
@@ -300,7 +298,7 @@ func (c *Controller) getAuthor(ctx context.Context, authorID int64) ([]byte, err
 
 	// Ensuring relationships doesn't block.
 	go func() {
-		c.ensureG.Go(func() error {
+		c.refreshG.Go(func() error {
 			ctx := context.Background()
 
 			defer func() {
@@ -313,9 +311,9 @@ func (c *Controller) getAuthor(ctx context.Context, authorID int64) ([]byte, err
 			var cached AuthorResource
 			_ = json.Unmarshal(cachedBytes, &cached)
 
-			workIDsToEnsure := []int64{}
+			workIDSToDenormalize := []int64{}
 			for _, w := range cached.Works {
-				workIDsToEnsure = append(workIDsToEnsure, w.ForeignID)
+				workIDSToDenormalize = append(workIDSToDenormalize, w.ForeignID)
 			}
 
 			// Finally try to load all of the author's works to ensure we have them.
@@ -334,17 +332,17 @@ func (c *Controller) getAuthor(ctx context.Context, authorID int64) ([]byte, err
 				var w workResource
 				_ = json.Unmarshal(bookBytes, &w)
 				workID := w.ForeignID
-				workIDsToEnsure = append(workIDsToEnsure, workID)
+				workIDSToDenormalize = append(workIDSToDenormalize, workID)
 				n++
 			}
 
-			slices.Sort(workIDsToEnsure)
-			workIDsToEnsure = slices.Compact(workIDsToEnsure)
+			slices.Sort(workIDSToDenormalize)
+			workIDSToDenormalize = slices.Compact(workIDSToDenormalize)
 
-			if len(workIDsToEnsure) > 0 {
-				c.ensureC <- edge{kind: authorEdge, parentID: authorID, childIDs: workIDsToEnsure}
+			if len(workIDSToDenormalize) > 0 {
+				c.denormC <- edge{kind: authorEdge, parentID: authorID, childIDs: workIDSToDenormalize}
 			}
-			Log(ctx).Info("fetched all works for author", "authorID", authorID, "count", len(workIDsToEnsure), "duration", time.Since(start))
+			Log(ctx).Info("fetched all works for author", "authorID", authorID, "count", len(workIDSToDenormalize), "duration", time.Since(start))
 
 			return nil
 		})
@@ -361,15 +359,15 @@ func (c *Controller) getAuthor(ctx context.Context, authorID int64) ([]byte, err
 // Run is responsible for denormalizing data. Race conditions are still
 // possible but less likely by serializing updates this way.
 func (c *Controller) Run(ctx context.Context, wait time.Duration) {
-	for edge := range groupEdges(c.ensureC, wait) {
+	for edge := range groupEdges(c.denormC, wait) {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 		switch edge.kind {
 		case authorEdge:
-			if err := c.ensureWorks(ctx, edge.parentID, edge.childIDs...); err != nil {
+			if err := c.denormalizeWorks(ctx, edge.parentID, edge.childIDs...); err != nil {
 				Log(ctx).Warn("problem ensuring work", "err", err, "authorID", edge.parentID, "workIDs", edge.childIDs)
 			}
 		case workEdge:
-			if err := c.ensureEditions(ctx, edge.parentID, edge.childIDs...); err != nil {
+			if err := c.denormalizeEditions(ctx, edge.parentID, edge.childIDs...); err != nil {
 				Log(ctx).Warn("problem ensuring edition", "err", err, "workID", edge.parentID, "bookIDs", edge.childIDs)
 			}
 		}
@@ -377,17 +375,17 @@ func (c *Controller) Run(ctx context.Context, wait time.Duration) {
 	}
 }
 
-// Shutdown waits for all "ensure" goroutines to finish submitting their work
-// and then closes the ensure channel. Run will run to completion after
-// Shutdown is called.
+// Shutdown waits for all refresh and denormalization goroutines to finish
+// submitting their work and then closes the denormalization channel. Run will
+// run to completion after Shutdown is called.
 func (c *Controller) Shutdown(ctx context.Context) {
-	_ = c.ensureG.Wait()
-	close(c.ensureC)
+	_ = c.refreshG.Wait()
+	close(c.denormC)
 }
 
-// ensureEditions ensures that the given editions exists on the work. It
+// denormalizeEditions ensures that the given editions exists on the work. It
 // deserializes the target work once. (TODO: No-op if it includes an edition
-// with the same title).
+// with the same language and title).
 //
 // This is what allows us to support translated editions. We intentionally
 // don't add every edition available, because then the user has potentially
@@ -398,7 +396,7 @@ func (c *Controller) Shutdown(ctx context.Context) {
 // (b) only add editions that are meaningful enough to appear in auto_complete,
 // and (c) keep the total number of editions small enough for users to more
 // easily select from.
-func (c *Controller) ensureEditions(ctx context.Context, workID int64, bookIDs ...int64) error {
+func (c *Controller) denormalizeEditions(ctx context.Context, workID int64, bookIDs ...int64) error {
 	if len(bookIDs) == 0 {
 		return nil
 	}
@@ -427,7 +425,7 @@ func (c *Controller) ensureEditions(ctx context.Context, workID int64, bookIDs .
 		workBytes, _, _, err = c.getter.GetBook(ctx, bookID)
 		if err != nil {
 			// Maybe the cache wasn't able to refresh because it was deleted? Move on.
-			Log(ctx).Warn("unable to ensure edition", "err", err, "workID", workID, "bookID", bookID)
+			Log(ctx).Warn("unable to denormalize edition", "err", err, "workID", workID, "bookID", bookID)
 			continue
 		}
 
@@ -468,9 +466,9 @@ func (c *Controller) ensureEditions(ctx context.Context, workID int64, bookIDs .
 	c.cache.Set(ctx, WorkKey(workID), out, fuzz(_workTTL, 1.5))
 
 	// We modified the work, so the author also needs to be updated. Remove the
-	// relationship so it doesn't no-op during the ensure.
+	// relationship so it doesn't no-op during the denormalization.
 	go func() {
-		c.ensureG.Go(func() error {
+		c.refreshG.Go(func() error {
 			ctx := context.Background()
 
 			defer func() {
@@ -480,7 +478,7 @@ func (c *Controller) ensureEditions(ctx context.Context, workID int64, bookIDs .
 			}()
 
 			for _, author := range work.Authors {
-				c.ensureC <- edge{kind: authorEdge, parentID: author.ForeignID, childIDs: []int64{workID}}
+				c.denormC <- edge{kind: authorEdge, parentID: author.ForeignID, childIDs: []int64{workID}}
 			}
 
 			return nil
@@ -490,10 +488,10 @@ func (c *Controller) ensureEditions(ctx context.Context, workID int64, bookIDs .
 	return nil
 }
 
-// ensureWorks ensures that the given works exist on the author. This is a
+// denormalizeWorks ensures that the given works exist on the author. This is a
 // no-op if our cached work already includes the work's ID. This is meant to be
 // invoked in the background, and it's what allows us to support large authors.
-func (c *Controller) ensureWorks(ctx context.Context, authorID int64, workIDs ...int64) error {
+func (c *Controller) denormalizeWorks(ctx context.Context, authorID int64, workIDs ...int64) error {
 	if len(workIDs) == 0 {
 		return nil
 	}
@@ -503,7 +501,7 @@ func (c *Controller) ensureWorks(ctx context.Context, authorID int64, workIDs ..
 		a, err = c.GetAuthor(ctx, authorID) // Reload if we got a cold cache.
 	}
 	if err != nil {
-		Log(ctx).Debug("problem loading author for ensureWorks", "err", err)
+		Log(ctx).Debug("problem loading author for denormalizeWorks", "err", err)
 		return err
 	}
 	var author AuthorResource
@@ -525,7 +523,7 @@ func (c *Controller) ensureWorks(ctx context.Context, authorID int64, workIDs ..
 		workBytes, _, err := c.getter.GetWork(ctx, workID)
 		if err != nil {
 			// Maybe the cache wasn't able to refresh because it was deleted? Move on.
-			Log(ctx).Warn("unable to ensure work", "err", err, "authorID", authorID, "workID", workID)
+			Log(ctx).Warn("unable to denormalize work", "err", err, "authorID", authorID, "workID", workID)
 			continue
 		}
 

--- a/internal/controller_test.go
+++ b/internal/controller_test.go
@@ -30,7 +30,8 @@ func TestIncrementalDenormalization(t *testing.T) {
 	frenchEdition := bookResource{ForeignID: 200, Language: "fr"}
 	work.Books = []bookResource{englishEdition}
 
-	author := AuthorResource{ForeignID: 1000, Works: []workResource{work}}
+	authorID := int64(1000)
+	author := AuthorResource{ForeignID: authorID, Works: []workResource{work}}
 
 	work.Authors = []AuthorResource{author}
 
@@ -66,7 +67,7 @@ func TestIncrementalDenormalization(t *testing.T) {
 		if ok {
 			return cachedBytes, 0, 0, nil
 		}
-		return englishEditionBytes, work.ForeignID, author.ForeignID, nil
+		return englishEditionBytes, work.ForeignID, authorID, nil
 	}).AnyTimes()
 
 	getter.EXPECT().GetBook(gomock.Any(), frenchEdition.ForeignID).DoAndReturn(func(ctx context.Context, bookID int64) ([]byte, int64, int64, error) {
@@ -74,7 +75,7 @@ func TestIncrementalDenormalization(t *testing.T) {
 		if ok {
 			return cachedBytes, 0, 0, nil
 		}
-		return frenchEditionBytes, work.ForeignID, author.ForeignID, nil
+		return frenchEditionBytes, work.ForeignID, authorID, nil
 	}).AnyTimes()
 
 	getter.EXPECT().GetWork(gomock.Any(), work.ForeignID).DoAndReturn(func(ctx context.Context, workID int64) ([]byte, int64, error) {
@@ -85,7 +86,7 @@ func TestIncrementalDenormalization(t *testing.T) {
 		return initialWorkBytes, author.ForeignID, nil
 	}).AnyTimes()
 
-	getter.EXPECT().GetAuthorBooks(gomock.Any(), author.ForeignID).Return(
+	getter.EXPECT().GetAuthorBooks(gomock.Any(), authorID).Return(
 		func(yield func(int64) bool) {
 			if !yield(englishEdition.ForeignID) {
 				return

--- a/internal/controller_test.go
+++ b/internal/controller_test.go
@@ -49,7 +49,7 @@ func TestIncrementalEnsure(t *testing.T) {
 	require.NoError(t, err)
 
 	go func() {
-		ctrl.Run(ctx)
+		ctrl.Run(ctx, 0)
 	}()
 
 	// TODO: Generalize this into a test helper.
@@ -385,4 +385,98 @@ func TestSubtitles(t *testing.T) {
 	assert.Equal(t, "Bar", author.Works[4].Books[1].Title)
 
 	assert.Equal(t, "Baz: The Baz Series #3", author.Works[5].Books[0].Title)
+}
+
+// TestEnsureSortedInvariant ensures we correct any lingering data not sorted
+// by ForeignID. This invairant is necessary for fast lookups and replacements
+// when updating works and editions.
+func TestEnsureSortedInvariant(t *testing.T) {
+	cache := &LayeredCache{wrapped: []cache.SetterCacheInterface[[]byte]{newMemory()}}
+
+	t.Run("ensureWorks", func(t *testing.T) {
+		c := gomock.NewController(t)
+		getter := NewMockgetter(c)
+		ctrl, err := NewController(cache, getter)
+		require.NoError(t, err)
+
+		author := AuthorResource{
+			ForeignID: 1,
+			Works: []workResource{
+				{ForeignID: 1},
+				{ForeignID: 2},
+				{ForeignID: 1},
+				{ForeignID: 3},
+			},
+		}
+
+		getter.EXPECT().GetWork(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, id int64) ([]byte, int64, error) {
+			bytes, err := json.Marshal(workResource{ForeignID: id, Books: []bookResource{{}}})
+			return bytes, 0, err
+		}).AnyTimes()
+
+		authorBytes, err := json.Marshal(author)
+		require.NoError(t, err)
+
+		cache.Set(t.Context(), AuthorKey(1), authorBytes, time.Hour)
+
+		err = ctrl.ensureWorks(t.Context(), author.ForeignID, 3)
+		require.NoError(t, err)
+
+		authorBytes, ok := cache.Get(t.Context(), AuthorKey(author.ForeignID))
+		require.True(t, ok)
+
+		err = json.Unmarshal(authorBytes, &author)
+		require.NoError(t, err)
+		assert.Equal(t, author.Works, []workResource{
+			{ForeignID: 1},
+			{ForeignID: 2},
+			{ForeignID: 3, Books: []bookResource{{}}},
+		})
+	})
+
+	t.Run("ensureEditions", func(t *testing.T) {
+		c := gomock.NewController(t)
+		getter := NewMockgetter(c)
+		ctrl, err := NewController(cache, getter)
+		require.NoError(t, err)
+
+		work := workResource{
+			ForeignID: 1,
+			Books: []bookResource{
+				{ForeignID: 10},
+				{ForeignID: 20},
+				{ForeignID: 10},
+				{ForeignID: 30},
+			},
+		}
+
+		getter.EXPECT().GetWork(gomock.Any(), work.ForeignID).DoAndReturn(func(ctx context.Context, id int64) ([]byte, int64, error) {
+			workBytes, err := json.Marshal(work)
+			return workBytes, 0, err
+		})
+
+		getter.EXPECT().GetBook(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, id int64) ([]byte, int64, int64, error) {
+			bytes, err := json.Marshal(workResource{ForeignID: work.ForeignID, Books: []bookResource{{ForeignID: id}}})
+			return bytes, 0, 0, err
+		}).AnyTimes()
+
+		workBytes, err := json.Marshal(work)
+		require.NoError(t, err)
+
+		cache.Set(t.Context(), WorkKey(1), workBytes, time.Hour)
+
+		err = ctrl.ensureEditions(t.Context(), work.ForeignID, 10)
+		require.NoError(t, err)
+
+		workBytes, ok := cache.Get(t.Context(), WorkKey(work.ForeignID))
+		require.True(t, ok)
+
+		err = json.Unmarshal(workBytes, &work)
+		require.NoError(t, err)
+		assert.Equal(t, work.Books, []bookResource{
+			{ForeignID: 10},
+			{ForeignID: 20},
+			{ForeignID: 30},
+		})
+	})
 }

--- a/internal/edges.go
+++ b/internal/edges.go
@@ -1,5 +1,10 @@
 package internal
 
+import (
+	"iter"
+	"time"
+)
+
 type edgeKind int
 
 const (
@@ -12,4 +17,46 @@ type edge struct {
 	kind     edgeKind
 	parentID int64
 	childIDs []int64
+}
+
+// groupEdges collects edges of the same kind and parent together in order to
+// reduce the number of times we deserialize the parent during denormalization.
+//
+// If an edge isn't seen after the wait duration then we yield the last edge we
+// saw.
+func groupEdges(edges chan edge, wait time.Duration) iter.Seq[edge] {
+	return func(yield func(edge) bool) {
+		var next edge
+		var ok bool
+
+		edge := <-edges
+		for {
+			select {
+			case next, ok = <-edges:
+				if !ok {
+					// Channel is closed.
+					_ = yield(edge)
+					return
+				}
+			case <-time.After(wait):
+				if !yield(edge) {
+					return
+				}
+			}
+
+			// If the next edge is for the same parent and kind, then aggregate
+			// its children into ours and move on.
+			if edge.parentID == next.parentID && edge.kind == next.kind {
+				edge.childIDs = append(edge.childIDs, next.childIDs...)
+				continue
+			}
+
+			// Next edge is for a different parent, so yield our current edge.
+			if !yield(edge) {
+				return
+			}
+
+			edge = next
+		}
+	}
 }

--- a/internal/edges_test.go
+++ b/internal/edges_test.go
@@ -1,0 +1,32 @@
+package internal
+
+import (
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGroupEdges(t *testing.T) {
+	c := make(chan edge)
+	go func() {
+		c <- edge{kind: authorEdge, parentID: 100, childIDs: []int64{1}}
+		c <- edge{kind: authorEdge, parentID: 100, childIDs: []int64{2, 3}}
+		c <- edge{kind: workEdge, parentID: 100, childIDs: []int64{4}}
+		c <- edge{kind: authorEdge, parentID: 100, childIDs: []int64{5, 6}}
+		c <- edge{kind: authorEdge, parentID: 200, childIDs: []int64{7}}
+		c <- edge{kind: authorEdge, parentID: 100, childIDs: []int64{8}}
+		c <- edge{kind: authorEdge, parentID: 300, childIDs: []int64{9}}
+		close(c)
+	}()
+
+	edges := slices.Collect(groupEdges(c, time.Second))
+
+	assert.Equal(t, edges[0], edge{kind: authorEdge, parentID: 100, childIDs: []int64{1, 2, 3}})
+	assert.Equal(t, edges[1], edge{kind: workEdge, parentID: 100, childIDs: []int64{4}})
+	assert.Equal(t, edges[2], edge{kind: authorEdge, parentID: 100, childIDs: []int64{5, 6}})
+	assert.Equal(t, edges[3], edge{kind: authorEdge, parentID: 200, childIDs: []int64{7}})
+	assert.Equal(t, edges[4], edge{kind: authorEdge, parentID: 100, childIDs: []int64{8}})
+	assert.Equal(t, edges[5], edge{kind: authorEdge, parentID: 300, childIDs: []int64{9}})
+}

--- a/internal/hardcover.go
+++ b/internal/hardcover.go
@@ -216,7 +216,7 @@ func (g *HCGetter) GetBook(ctx context.Context, grBookID int64) ([]byte, int64, 
 
 	// If we haven't already cached this author do so now, because we don't
 	// normally have a way to lookup GR Author ID -> HC Author. This will get
-	// incrementally filled in by ensureWork.
+	// incrementally filled in by denormalizeWorks.
 	if _, ok := g.cache.Get(ctx, AuthorKey(grAuthorID)); !ok {
 		authorBytes, _ := json.Marshal(authorRsc)
 		g.cache.Set(ctx, AuthorKey(grAuthorID), authorBytes, _authorTTL)

--- a/internal/hardcover_test.go
+++ b/internal/hardcover_test.go
@@ -233,7 +233,7 @@ func TestGetBookDataIntegrity(t *testing.T) {
 	ctrl, err := NewController(cache, getter)
 	require.NoError(t, err)
 
-	go ctrl.Run(context.Background()) // Denormalize data in the background.
+	go ctrl.Run(context.Background(), 0) // Denormalize data in the background.
 
 	t.Run("GetBook", func(t *testing.T) {
 		bookBytes, err := ctrl.GetBook(ctx, 6609765)

--- a/internal/postgres_test.go
+++ b/internal/postgres_test.go
@@ -58,7 +58,7 @@ func TestPostgresCache(t *testing.T) {
 	cache, err := NewCache(ctx, dsn)
 	require.NoError(t, err)
 
-	n := 500
+	n := 400
 	wg := sync.WaitGroup{}
 
 	for i := range n {


### PR DESCRIPTION
A user reported an issue where they weren't able to add an author. Ultimately it was due to the author having a duplicated work, but this shouldn't happen under normal circumstances. We keep the author's works sorted by foreign id, and we rely on this sort order when updating things. 

When I first introduced the sorted invariant I had some logic to sort things that weren't already sorted. I thought enough time had passed for it to be safe to remove that logic, but that might not have been the case. Or there might be a different bug causing things to get out of order.

In any case, this adds some logic to repair + log when we find things out of order. It also makes our denormalization steps more efficient.