### PR TITLE
Reject OL IDs

### DIFF
--- a/internal/handler.go
+++ b/internal/handler.go
@@ -396,5 +396,13 @@ func pathToID(p string) (int64, error) {
 	if i <= 0 {
 		return i, errors.Join(fmt.Errorf("expected %d to be positive", i), errBadRequest)
 	}
+
+	// The OL metadata server can send IDs over 1B which we don't want to handle.
+	// ID < 1 billion -> GR
+	// ID > 1 billion -> OL
+	if i > 1000000000 {
+		return i, errors.Join(errBadRequest, errors.New("OpenLibrary IDs are not supported"))
+	}
+
 	return i, nil
 }

--- a/internal/handler_test.go
+++ b/internal/handler_test.go
@@ -37,6 +37,11 @@ func TestPathToID(t *testing.T) {
 			want:    -1234,
 			wantErr: errBadRequest,
 		},
+		{
+			given:   "/author/10000000000",
+			want:    10000000000,
+			wantErr: errBadRequest,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Users that have used the OL metadata server can have IDs in their DB with a value over 1B. That's how the OL server differentiates OL from GR foreign IDs.

We don't currently handle these, so reject them as a 400 instead of processing them (and eventually returning a 404).