### PR TITLE
Return individualized errors when batching queries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
         shell: bash
         env:
           HARDCOVER_API_KEY: ${{ secrets.HARDCOVER_API_KEY }}
+          GRHOST: ${{ secrets.GRHOST }}
 
       - uses: codecov/codecov-action@v5.1.2
         with:

--- a/internal/controller.go
+++ b/internal/controller.go
@@ -79,7 +79,7 @@ func NewUpstream(host string, cookie string, proxy string) (*http.Client, error)
 			Limiter: rate.NewLimiter(rate.Every(time.Hour/60), 1),
 			RoundTripper: ScopedTransport{
 				Host:         host,
-				RoundTripper: ErrorProxyTransport{http.DefaultTransport},
+				RoundTripper: errorProxyTransport{http.DefaultTransport},
 			},
 		},
 		CheckRedirect: func(req *http.Request, _ []*http.Request) error {
@@ -103,7 +103,7 @@ func NewUpstream(host string, cookie string, proxy string) (*http.Client, error)
 				Host: host,
 				RoundTripper: cookieTransport{
 					cookies:      cookies,
-					RoundTripper: ErrorProxyTransport{http.DefaultTransport},
+					RoundTripper: errorProxyTransport{http.DefaultTransport},
 				},
 			},
 		}

--- a/internal/graphql_test.go
+++ b/internal/graphql_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/blampe/rreading-glasses/hardcover"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
 func TestQueryBuilder(t *testing.T) {
@@ -182,4 +183,13 @@ func TestBatching(t *testing.T) {
 	wg.Wait()
 
 	assert.Less(t, time.Since(start), 4*time.Second)
+}
+
+func TestGQLStatusCode(t *testing.T) {
+	err := &gqlerror.Error{Message: "womp"}
+	assert.ErrorIs(t, err, gqlStatusErr(err))
+
+	err = &gqlerror.Error{Message: "Request failed with status code 403"}
+	err403 := statusErr(403)
+	assert.ErrorAs(t, gqlStatusErr(err), &err403)
 }

--- a/internal/transport.go
+++ b/internal/transport.go
@@ -75,15 +75,15 @@ func (t HeaderTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	return t.RoundTripper.RoundTrip(r)
 }
 
-// ErrorProxyTransport returns a non-nil statusErr for all response codes 400
+// errorProxyTransport returns a non-nil statusErr for all response codes 400
 // and above so we can return a response with the same code.
-type ErrorProxyTransport struct {
+type errorProxyTransport struct {
 	http.RoundTripper
 }
 
 // RoundTrip wraps upstream 4XX and 5XX errors such that they are returned
 // directly to the client.
-func (t ErrorProxyTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+func (t errorProxyTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	resp, err := t.RoundTripper.RoundTrip(r)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Right now if one of our queries fails, for example with a 404, the entire batch of queries will get the same error.

This modifies our error handling to inspect the returned `gqlerror.List` and return errors to the appropriate subscribers.

While testing this I happened to trigger the WAF, so I'm also modifying the auth logic to fall back to using the default token if we fail to refresh creds. The alternative will usually put the crash into a crash loop, which makes the situation worse.