### PR TITLE
Fix gql auth

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+gr/schema.graphql linguist-generated=true
+hardcover/schema.graphql linguist-generated=true

--- a/cmd/rghc/main.go
+++ b/cmd/rghc/main.go
@@ -53,7 +53,7 @@ func (s *server) Run() error {
 
 	hcTransport := internal.ScopedTransport{
 		Host: "api.hardcover.app",
-		RoundTripper: internal.HeaderTransport{
+		RoundTripper: &internal.HeaderTransport{
 			Key:          "Authorization",
 			Value:        s.HardcoverAuth,
 			RoundTripper: http.DefaultTransport,

--- a/gr/schema.graphql
+++ b/gr/schema.graphql
@@ -4,9 +4,19 @@ This directive allows results to be deferred during execution
 directive @defer on FIELD
 
 """
-Tells the service this field/object has access authorized by a Lambda Authorizer.
+Tells the service which mutation triggers this subscription.
 """
-directive @aws_lambda on OBJECT | FIELD_DEFINITION
+directive @aws_subscribe(
+  """
+  List of mutations which will trigger this subscription when they are called.
+  """
+  mutations: [String]
+) on FIELD_DEFINITION
+
+"""
+Tells the service this field/object has access authorized by sigv4 signing.
+"""
+directive @aws_iam on OBJECT | FIELD_DEFINITION
 
 """
 Tells the service which subscriptions will be published to when this mutation is called. This directive is deprecated use @aws_susbscribe directive instead.
@@ -16,36 +26,6 @@ directive @aws_publish(
   List of subscriptions which will be published to when this mutation is called.
   """
   subscriptions: [String]
-) on FIELD_DEFINITION
-
-"""
-Directs the schema to enforce authorization on a field
-"""
-directive @aws_auth(
-  """
-  List of cognito user pool groups which have access on this field
-  """
-  cognito_groups: [String]
-) on FIELD_DEFINITION
-
-"""
-Tells the service this field/object has access authorized by a Cognito User Pools token.
-"""
-directive @aws_cognito_user_pools(
-  """
-  List of cognito user pool groups which have access on this field
-  """
-  cognito_groups: [String]
-) on OBJECT | FIELD_DEFINITION
-
-"""
-Tells the service which mutation triggers this subscription.
-"""
-directive @aws_subscribe(
-  """
-  List of mutations which will trigger this subscription when they are called.
-  """
-  mutations: [String]
 ) on FIELD_DEFINITION
 
 """
@@ -59,17 +39,37 @@ Tells the service this field/object has access authorized by an OIDC token.
 directive @aws_oidc on OBJECT | FIELD_DEFINITION
 
 """
-Tells the service this field/object has access authorized by sigv4 signing.
+Tells the service this field/object has access authorized by a Cognito User Pools token.
 """
-directive @aws_iam on OBJECT | FIELD_DEFINITION
+directive @aws_cognito_user_pools(
+  """
+  List of cognito user pool groups which have access on this field
+  """
+  cognito_groups: [String]
+) on OBJECT | FIELD_DEFINITION
+
+"""
+Directs the schema to enforce authorization on a field
+"""
+directive @aws_auth(
+  """
+  List of cognito user pool groups which have access on this field
+  """
+  cognito_groups: [String]
+) on FIELD_DEFINITION
+
+"""
+Tells the service this field/object has access authorized by a Lambda Authorizer.
+"""
+directive @aws_lambda on OBJECT | FIELD_DEFINITION
 
 type Query {
+  getAdspAd(input: GetAdspAdInput!): AdspAd
   getAdsTargeting(getAdsTargetingInput: GetAdsTargetingInput): AdsTargeting
   getBasicGenres(pagination: PaginationInput): GenreCollection
   getBlockedUsers(pagination: PaginationInput): BlockedUsersConnection
   getBlog(id: ID!): Blog
   getBook(id: ID!): Book
-  getBooks(uris: [String!], paginationInput: PaginationInput): BooksConnection!
   getBookByLegacyId(legacyId: Int!): Book
   getBookListsOfBook(
     id: ID!
@@ -89,6 +89,7 @@ type Query {
     filters: CommentFiltersInput!
     pagination: PaginationInput
   ): ResourceCommentsConnection
+  getCtaBanners: [CtaBanner]
   getEditions(id: ID!, pagination: PaginationInput): BooksConnection
   getFeaturedArticlesByWork(id: ID!): [FeaturedArticle]
   getFeaturedBookLists(paginationInput: PaginationInput): BookListsConnection!
@@ -177,6 +178,25 @@ type Query {
     discussionInput: DiscussionInput!
     pagination: PaginationInput
   ): ResourceTopicsConnection
+}
+
+type AdspAd {
+  adFeedbackUrl: String!
+  rawHtml: String!
+}
+
+input GetAdspAdInput {
+  adSize: AdSize
+  age: String!
+  customerId: String!
+  deviceId: String!
+  iba: Boolean!
+  placement: String!
+}
+
+input AdSize {
+  height: Int!
+  width: Int!
 }
 
 type AdsTargeting {
@@ -272,6 +292,7 @@ type User implements Node {
   reviewsCount: Int
   shelvesAndTags(maxShelves: Int, maxTags: Int): ShelvesAndTags
   textReviewsCount: Int
+  urcFriendChallengeUrl(userUri: ID!, year: String!, useViewer: String): String
   viewerFriendRequestsUnreadCount: Int
   viewerMessagesUnreadCount: Int
   viewerNotifications(pagination: PaginationInput): NotificationsConnection
@@ -532,6 +553,7 @@ type Review implements Node & Likable & Commentable {
   id: ID!
   lastRevisionAt: Float
   likeCount: Int
+  preReleaseBookSource: String
   rating: Int
   recommendFor: String
   shelving: Shelving
@@ -574,6 +596,9 @@ type Shelving implements Node {
 }
 
 type Shelf {
+  default: Boolean
+  displayName: String
+  editable: Boolean
   id: ID
   legacyId: Int
   name: String
@@ -636,6 +661,8 @@ type SimilarBooksEdge implements Edge {
 type SocialSignal {
   count: Int!
   name: ShelfStatus!
+  shelfPhrase: String
+  userPhrase: String
   users: [SocialSignalUserEdge]!
 }
 
@@ -1038,6 +1065,18 @@ input CommentFiltersInput {
 enum CommentsSortOption {
   NEWEST
   OLDEST
+}
+
+type CtaBanner {
+  backgroundColor: String
+  body: String
+  id: String
+  imageUrl: String
+  largeImageUrl: String
+  link: String
+  smallImageUrl: String
+  textColor: String
+  title: String
 }
 
 type FeaturedArticle {
@@ -1456,6 +1495,7 @@ type RateBookPayload {
 
 input RateBookInput {
   id: ID!
+  preReleaseBookSource: String
   rating: Int!
 }
 
@@ -1552,66 +1592,8 @@ input UserSubscriptionInput {
   value: String!
 }
 
-type HomeWidgetInterviewEdge implements HomeWidgetItemEdge & Edge {
-  dataType: HomeWidgetDataType
-  metadata: [HomeWidgetMetadataMap]
-  node: Interview!
-  score: Float
-}
-
-enum HomeWidgetDataType {
-  BLOG
-  BOOK
-  INTERVIEW
-  WORK
-}
-
-interface HomeWidgetItemEdge {
-  dataType: HomeWidgetDataType
-  metadata: [HomeWidgetMetadataMap]
-  score: Float
-}
-
-type HomeWidgetWorkEdge implements HomeWidgetItemEdge & Edge {
-  dataType: HomeWidgetDataType
-  metadata: [HomeWidgetMetadataMap]
-  node: Work!
-  score: Float
-}
-
-type HomeWidgetReviewEdge implements HomeWidgetItemEdge & Edge {
-  dataType: HomeWidgetDataType
-  metadata: [HomeWidgetMetadataMap]
-  node: Review!
-  score: Float
-}
-
-type BookAd implements NativeAd {
-  book: Book!
-  customDescription: String
-  id: ID!
-  viewerNotInterested: Boolean
-}
-
-type HomeWidgetBlogEdge implements HomeWidgetItemEdge & Edge {
-  dataType: HomeWidgetDataType
-  metadata: [HomeWidgetMetadataMap]
-  node: Blog!
-  score: Float
-}
-
 type ArticleInterviewEdge implements Edge & ArticleEdge {
   node: Interview!
-}
-
-type ArticleBlogEdge implements Edge & ArticleEdge {
-  node: Blog!
-}
-
-type RatingsSocialSignal implements WorkSocialSignal {
-  count: Int!
-  edges: [SocialSignalUserEdge]!
-  rating: Int!
 }
 
 type HomeWidgetBookEdge implements HomeWidgetItemEdge & Edge {
@@ -1622,32 +1604,41 @@ type HomeWidgetBookEdge implements HomeWidgetItemEdge & Edge {
   source: Book
 }
 
+enum HomeWidgetDataType {
+  BLOG
+  BOOK
+  INTERVIEW
+  WORK
+}
+
 type HomeWidgetBook implements Node {
   book: Book
   id: ID!
 }
 
-type TopListBookEdge implements Edge & TopListEdge {
-  count: Int
-  node: Book!
-  rank: Int!
-}
-
-interface TopListEdge {
-  count: Int
-  rank: Int!
-}
-
-type TopListWorkEdge implements Edge & TopListEdge {
-  count: Int
-  node: Work!
-  rank: Int!
+interface HomeWidgetItemEdge {
+  dataType: HomeWidgetDataType
+  metadata: [HomeWidgetMetadataMap]
+  score: Float
 }
 
 type ShelvingsSocialSignal implements WorkSocialSignal {
   count: Int!
   edges: [SocialSignalUserEdge]!
   shelfName: ShelfName!
+  shelfPhrase: String
+  userPhrase: String
+}
+
+type ArticleBlogEdge implements Edge & ArticleEdge {
+  node: Blog!
+}
+
+type HomeWidgetInterviewEdge implements HomeWidgetItemEdge & Edge {
+  dataType: HomeWidgetDataType
+  metadata: [HomeWidgetMetadataMap]
+  node: Interview!
+  score: Float
 }
 
 type KindleLink implements Link {
@@ -1659,15 +1650,11 @@ type KindleLink implements Link {
   url: String!
 }
 
-type SearchBookEdge implements Edge & SearchResultEdge {
-  node: Book!
-  rank: Int
-}
-
-type TopListUserEdge implements Edge & TopListEdge {
-  count: Int
-  node: User!
-  rank: Int!
+type HomeWidgetBlogEdge implements HomeWidgetItemEdge & Edge {
+  dataType: HomeWidgetDataType
+  metadata: [HomeWidgetMetadataMap]
+  node: Blog!
+  score: Float
 }
 
 type FlexAd implements NativeAd {
@@ -1686,4 +1673,59 @@ type FlexAd implements NativeAd {
   sponsorName: String
   sponsorUrl: String
   viewerNotInterested: Boolean
+}
+
+type HomeWidgetWorkEdge implements HomeWidgetItemEdge & Edge {
+  dataType: HomeWidgetDataType
+  metadata: [HomeWidgetMetadataMap]
+  node: Work!
+  score: Float
+}
+
+type HomeWidgetReviewEdge implements HomeWidgetItemEdge & Edge {
+  dataType: HomeWidgetDataType
+  metadata: [HomeWidgetMetadataMap]
+  node: Review!
+  score: Float
+}
+
+type TopListUserEdge implements Edge & TopListEdge {
+  count: Int
+  node: User!
+  rank: Int!
+}
+
+interface TopListEdge {
+  count: Int
+  rank: Int!
+}
+
+type BookAd implements NativeAd {
+  book: Book!
+  customDescription: String
+  id: ID!
+  viewerNotInterested: Boolean
+}
+
+type RatingsSocialSignal implements WorkSocialSignal {
+  count: Int!
+  edges: [SocialSignalUserEdge]!
+  rating: Int!
+}
+
+type SearchBookEdge implements Edge & SearchResultEdge {
+  node: Book!
+  rank: Int
+}
+
+type TopListBookEdge implements Edge & TopListEdge {
+  count: Int
+  node: Book!
+  rank: Int!
+}
+
+type TopListWorkEdge implements Edge & TopListEdge {
+  count: Int
+  node: Work!
+  rank: Int!
 }

--- a/internal/gr.go
+++ b/internal/gr.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"iter"
 	"net/http"
-	"net/http/httputil"
 	"strings"
 	"time"
 
@@ -92,45 +91,6 @@ func NewGRGQL(ctx context.Context, upstream *http.Client, cookie string) (graphq
 	*/
 
 	return NewBatchedGraphQLClient(string(host), &http.Client{Transport: auth}, rate)
-}
-
-// getGRCreds can be used to periodically refresh an auth token.
-func getGRCreds(ctx context.Context, upstream *http.Client) (string, error) {
-	Log(ctx).Debug("generating credentials")
-
-	getJWT, err := http.NewRequest("GET", "/open_id/auth_token", nil)
-	if err != nil {
-		return "", err
-	}
-
-	// This client_id is public and is easily obtainable. It's obscured here
-	// only to prevent it from showing up in search results. client_id, _ =
-	clientID, _ := hex.DecodeString("36336463323465376336313165366631373932663831333035386632313536306264386336393338643534612e676f6f6472656164732e636f6d")
-
-	params := getJWT.URL.Query()
-	params.Add("response_type", "token")
-	params.Add("client_id", string(clientID))
-	getJWT.URL.RawQuery = params.Encode()
-
-	resp, err := upstream.Do(getJWT)
-	if err != nil {
-		Log(ctx).Error("auth error! double check your cookie, it might be invalid or expired")
-		return "", err
-	}
-	if resp.StatusCode != http.StatusOK {
-		debug, _ := httputil.DumpResponse(resp, true)
-		Log(ctx).Error("auth error", "debug", string(debug))
-		return "", fmt.Errorf("unexpected status %q", resp.Status)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	for _, c := range resp.Cookies() {
-		if c.Name == "jwt_token" {
-			return c.Value, nil
-		}
-	}
-
-	return "", fmt.Errorf("no cookie found")
 }
 
 // GetWork returns a work with all known editions. Due to the way R—— works, if

--- a/internal/gr.go
+++ b/internal/gr.go
@@ -54,7 +54,7 @@ func NewGRGQL(ctx context.Context, upstream *http.Client, cookie string) (graphq
 		return nil, err
 	}
 
-	auth := HeaderTransport{
+	auth := &HeaderTransport{
 		Key:          "X-Api-Key",
 		Value:        string(defaultToken),
 		RoundTripper: http.DefaultTransport,
@@ -70,6 +70,7 @@ func NewGRGQL(ctx context.Context, upstream *http.Client, cookie string) (graphq
 		if err != nil {
 			return nil, err
 		}
+		auth.Key = "Authorization"
 		auth.Value = token
 
 		go func() {
@@ -78,8 +79,11 @@ func NewGRGQL(ctx context.Context, upstream *http.Client, cookie string) (graphq
 				token, err := getGRCreds(ctx, upstream)
 				if err != nil {
 					Log(ctx).Error("unable to refresh auth", "err", err)
-					token = string(defaultToken)
+					auth.Key = "X-Api-Key"
+					auth.Value = string(defaultToken)
+					continue
 				}
+				auth.Key = "Authorization"
 				auth.Value = token
 			}
 		}()

--- a/internal/gr_test.go
+++ b/internal/gr_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/Khan/genqlient/graphql"
 	"github.com/blampe/rreading-glasses/gr"
@@ -291,4 +292,59 @@ func TestBatchError(t *testing.T) {
 
 	gqlErr := &gqlerror.Error{}
 	assert.ErrorAs(t, err2, &gqlErr)
+}
+
+func TestAuth(t *testing.T) {
+	// Sanity check that we're authorized for all relevant endpoints.
+	host := os.Getenv("GRHOST")
+	if host == "" {
+		t.Skip("missing GRHOST env var")
+		return
+	}
+
+	cookie := os.Getenv("GR_TEST_COOKIE")
+	if cookie == "" {
+		t.Skip("missing GR_TEST_COOKIE")
+		return
+	}
+
+	cache := &LayeredCache{wrapped: []cache.SetterCacheInterface[[]byte]{newMemory()}}
+
+	upstream, err := NewUpstream(host, cookie, "")
+	require.NoError(t, err)
+
+	gql, err := NewGRGQL(t.Context(), upstream, cookie)
+	require.NoError(t, err)
+
+	getter, err := NewGRGetter(cache, gql, upstream)
+	require.NoError(t, err)
+	ctrl, err := NewController(cache, getter)
+	go ctrl.Run(t.Context(), time.Second)
+
+	require.NoError(t, err)
+
+	t.Run("GetAuthor", func(t *testing.T) {
+		_, err := ctrl.GetAuthor(t.Context(), 4178)
+		assert.NoError(t, err)
+	})
+
+	t.Run("GetBook", func(t *testing.T) {
+		_, err := ctrl.GetBook(t.Context(), 394535)
+		assert.NoError(t, err)
+	})
+
+	t.Run("GetWork", func(t *testing.T) {
+		_, err := ctrl.GetWork(t.Context(), 1930437)
+		assert.NoError(t, err)
+	})
+
+	t.Run("GetAuthorBooks", func(t *testing.T) {
+		iter := getter.GetAuthorBooks(t.Context(), 4178)
+		gotBook := false
+		for range iter {
+			gotBook = true
+			break
+		}
+		assert.True(t, gotBook)
+	})
 }

--- a/internal/gr_test.go
+++ b/internal/gr_test.go
@@ -295,6 +295,8 @@ func TestBatchError(t *testing.T) {
 }
 
 func TestAuth(t *testing.T) {
+	t.Parallel()
+
 	// Sanity check that we're authorized for all relevant endpoints.
 	host := os.Getenv("GRHOST")
 	if host == "" {
@@ -324,21 +326,25 @@ func TestAuth(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("GetAuthor", func(t *testing.T) {
+		t.Parallel()
 		_, err := ctrl.GetAuthor(t.Context(), 4178)
 		assert.NoError(t, err)
 	})
 
 	t.Run("GetBook", func(t *testing.T) {
+		t.Parallel()
 		_, err := ctrl.GetBook(t.Context(), 394535)
 		assert.NoError(t, err)
 	})
 
 	t.Run("GetWork", func(t *testing.T) {
+		t.Parallel()
 		_, err := ctrl.GetWork(t.Context(), 1930437)
 		assert.NoError(t, err)
 	})
 
 	t.Run("GetAuthorBooks", func(t *testing.T) {
+		t.Parallel()
 		iter := getter.GetAuthorBooks(t.Context(), 4178)
 		gotBook := false
 		for range iter {

--- a/internal/graphql_test.go
+++ b/internal/graphql_test.go
@@ -128,7 +128,7 @@ func TestBatching(t *testing.T) {
 		t.Skip("missing HARDCOVER_API_KEY")
 		return
 	}
-	transport := HeaderTransport{
+	transport := &HeaderTransport{
 		Key:          "Authorization",
 		Value:        "Bearer " + apiKey,
 		RoundTripper: http.DefaultTransport,

--- a/internal/transport.go
+++ b/internal/transport.go
@@ -70,7 +70,7 @@ type HeaderTransport struct {
 }
 
 // RoundTrip always sets the header on the request.
-func (t HeaderTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+func (t *HeaderTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	r.Header.Add(t.Key, t.Value)
 	return t.RoundTripper.RoundTrip(r)
 }


### PR DESCRIPTION
#112 modified the auth logic to always grab a JWT, whereas the previous behavior would use the public token until creds had been fetched.

As it turns out the previous behavior was never actually updating headers with the JWT due to a bug -- we just kept using the public token forever, only at a more generous 3RPS (which is fine).

Since the auth'd flow wasn't needed for gql we can turn it off. The code is left commented because it might eventually be needed.

Fixes https://github.com/blampe/rreading-glasses/issues/113.