### PR TITLE
add support for reading secrets from files (#119)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,25 +100,28 @@ Usage: rreading-glasses serve --upstream=STRING --hardcover-auth=STRING [flags]
 Run an HTTP server.
 
 Flags:
-  -h, --help                                    Show context-sensitive help.
+  -h, --help                                             Show context-sensitive help.
 
-      --postgres-host="localhost"               Postgres host.
-      --postgres-user="postgres"                Postgres user.
-      --postgres-password=""                    Postgres password.
-      --postgres-port=5432                      Postgres port.
-      --postgres-database="rreading-glasses"    Postgres database to use.
-      --verbose                                 increase log verbosity
-      --port=8788                               Port to serve traffic on.
-      --rpm=60                                  Maximum upstream requests per minute.
-      --cookie=STRING                           Cookie to use for upstream HTTP requests.
-      --proxy=""                                HTTP proxy URL to use for upstream requests.
-      --upstream=STRING                         Upstream host (e.g. www.example.com).
-      --hardcover-auth=STRING                   Hardcover Authorization header, e.g. 'Bearer ...'
+      --postgres-host="localhost"                        Postgres host ($POSTGRES_HOST).
+      --postgres-user="postgres"                         Postgres user ($POSTGRES_USER).
+      --postgres-password=STRING                         Postgres password ($POSTGRES_PASSWORD).
+      --postgres-password-file=POSTGRES-PASSWORD-FILE    File with the Postgres password ($POSTGRES_PASSWORD_FILE).
+      --postgres-port=5432                               Postgres port ($POSTGRES_PORT).
+      --postgres-database="rreading-glasses"             Postgres database to use ($POSTGRES_DATABASE).
+      --verbose                                          increase log verbosity ($VERBOSE)
+      --port=8788                                        Port to serve traffic on ($PORT).
+      --rpm=60                                           Maximum upstream requests per minute ($RPM).
+      --cookie=STRING                                    Cookie to use for upstream HTTP requests ($COOKIE).
+      --cookie-file=COOKIE-FILE                          File with the Cookie to use for upstream HTTP requests ($COOKIE_FILE).
+      --proxy=""                                         HTTP proxy URL to use for upstream requests ($PROXY).
+      --upstream=STRING                                  Upstream host (e.g. www.example.com) ($UPSTREAM).
+      --hardcover-auth=STRING                            Hardcover Authorization header, e.g. 'Bearer ...' ($HARDCOVER_AUTH)
+      --hardcover-auth-file=HARDCOVER-AUTH-FILE          File containing the Hardcover Authorization header, e.g. 'Bearer ...' ($HARDCOVER_AUTH_FILE)
 ```
-
 
 Two docker compose example files are included as a reference:
 `docker-compose-gr.yml` and `docker-compose-hardcover.yml`.
+
 
 ### G——R—— Cookie
 

--- a/cmd/rggr/main.go
+++ b/cmd/rggr/main.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"strings"
 	"time"
 
 	"github.com/alecthomas/kong"
@@ -48,8 +47,6 @@ func (s *server) Run() error {
 
 	if len(s.CookieFile) > 0 {
 		s.Cookie = string(s.CookieFile)
-		// Can't figure out where the new line is coming from.
-		s.Cookie = strings.TrimSuffix(s.Cookie, "\n")
 	}
 
 	upstream, err := internal.NewUpstream(s.Upstream, s.Cookie, s.Proxy)

--- a/cmd/rggr/main.go
+++ b/cmd/rggr/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -46,7 +47,7 @@ func (s *server) Run() error {
 	}
 
 	if len(s.CookieFile) > 0 {
-		s.Cookie = string(s.CookieFile)
+		s.Cookie = string(bytes.TrimSpace(s.CookieFile))
 	}
 
 	upstream, err := internal.NewUpstream(s.Upstream, s.Cookie, s.Proxy)

--- a/cmd/rggr/main.go
+++ b/cmd/rggr/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"time"
 
 	"github.com/alecthomas/kong"
@@ -28,11 +29,12 @@ type server struct {
 	cmd.PGConfig
 	cmd.LogConfig
 
-	Port     int    `default:"8788" env:"PORT" help:"Port to serve traffic on."`
-	RPM      int    `default:"60" env:"RPM" help:"Maximum upstream requests per minute."`
-	Cookie   string `env:"COOKIE" help:"Cookie to use for upstream HTTP requests."`
-	Proxy    string `default:"" env:"PROXY" help:"HTTP proxy URL to use for upstream requests."`
-	Upstream string `required:"" env:"UPSTREAM" help:"Upstream host (e.g. www.example.com)."`
+	Port       int    `default:"8788" env:"PORT" help:"Port to serve traffic on."`
+	RPM        int    `default:"60" env:"RPM" help:"Maximum upstream requests per minute."`
+	Cookie     string `required:"" xor:"cookie" env:"COOKIE" help:"Cookie to use for upstream HTTP requests."`
+	CookieFile []byte `required:"" type:"filecontent" xor:"cookie" env:"COOKIE_FILE" help:"File with the Cookie to use for upstream HTTP requests."`
+	Proxy      string `default:"" env:"PROXY" help:"HTTP proxy URL to use for upstream requests."`
+	Upstream   string `required:"" env:"UPSTREAM" help:"Upstream host (e.g. www.example.com)."`
 }
 
 func (s *server) Run() error {
@@ -42,6 +44,12 @@ func (s *server) Run() error {
 	cache, err := internal.NewCache(ctx, s.DSN())
 	if err != nil {
 		return fmt.Errorf("setting up cache: %w", err)
+	}
+
+	if len(s.CookieFile) > 0 {
+		s.Cookie = string(s.CookieFile)
+		// Can't figure out where the new line is coming from.
+		s.Cookie = strings.TrimSuffix(s.Cookie, "\n")
 	}
 
 	upstream, err := internal.NewUpstream(s.Upstream, s.Cookie, s.Proxy)

--- a/cmd/rghc/main.go
+++ b/cmd/rghc/main.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"strings"
 	"time"
 
 	"github.com/alecthomas/kong"
@@ -55,8 +54,6 @@ func (s *server) Run() error {
 
 	if len(s.HardcoverAuthFile) > 0 {
 		s.HardcoverAuth = string(s.HardcoverAuthFile)
-		// Can't figure out where the new line is coming from.
-		s.HardcoverAuth = strings.TrimSuffix(s.HardcoverAuth, "\n")
 	}
 
 	hcTransport := internal.ScopedTransport{

--- a/cmd/rghc/main.go
+++ b/cmd/rghc/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"time"
 
 	"github.com/alecthomas/kong"
@@ -34,7 +35,8 @@ type server struct {
 	Proxy    string `default:"" env:"PROXY" help:"HTTP proxy URL to use for upstream requests."`
 	Upstream string `required:"" env:"UPSTREAM" help:"Upstream host (e.g. www.example.com)."`
 
-	HardcoverAuth string `required:"" env:"HARDCOVER_AUTH" help:"Hardcover Authorization header, e.g. 'Bearer ...'"`
+	HardcoverAuth     string `required:"" env:"HARDCOVER_AUTH" xor:"hardcover-auth" help:"Hardcover Authorization header, e.g. 'Bearer ...'"`
+	HardcoverAuthFile []byte `required:"" type:"filecontent" xor:"hardcover-auth" env:"HARDCOVER_AUTH_FILE" help:"File containing the Hardcover Authorization header, e.g. 'Bearer ...'"`
 }
 
 func (s *server) Run() error {
@@ -49,6 +51,12 @@ func (s *server) Run() error {
 	upstream, err := internal.NewUpstream(s.Upstream, s.Cookie, s.Proxy)
 	if err != nil {
 		return err
+	}
+
+	if len(s.HardcoverAuthFile) > 0 {
+		s.HardcoverAuth = string(s.HardcoverAuthFile)
+		// Can't figure out where the new line is coming from.
+		s.HardcoverAuth = strings.TrimSuffix(s.HardcoverAuth, "\n")
 	}
 
 	hcTransport := internal.ScopedTransport{

--- a/cmd/rghc/main.go
+++ b/cmd/rghc/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -53,7 +54,7 @@ func (s *server) Run() error {
 	}
 
 	if len(s.HardcoverAuthFile) > 0 {
-		s.HardcoverAuth = string(s.HardcoverAuthFile)
+		s.HardcoverAuth = string(bytes.TrimSpace(s.HardcoverAuthFile))
 	}
 
 	hcTransport := internal.ScopedTransport{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
-	"strings"
 
 	"github.com/KimMachineGun/automemlimit/memlimit"
 	"github.com/blampe/rreading-glasses/internal"
@@ -29,8 +28,6 @@ type PGConfig struct {
 func (c *PGConfig) DSN() string {
 	if len(c.PostgresPasswordFile) > 0 {
 		c.PostgresPassword = string(c.PostgresPasswordFile)
-		// Can't figure out where the new line is coming from.
-		c.PostgresPassword = strings.TrimSuffix(c.PostgresPassword, "\n")
 	}
 
 	// Allow unix sockets.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -27,7 +28,7 @@ type PGConfig struct {
 // DSN returns the database's DSN based on the provided flags.
 func (c *PGConfig) DSN() string {
 	if len(c.PostgresPasswordFile) > 0 {
-		c.PostgresPassword = string(c.PostgresPasswordFile)
+		c.PostgresPassword = string(bytes.TrimSpace(c.PostgresPasswordFile))
 	}
 
 	// Allow unix sockets.

--- a/docker-compose-gr.yml
+++ b/docker-compose-gr.yml
@@ -11,13 +11,14 @@ services:
     entrypoint: ["/main", "serve"]
     command:    
       - --upstream=www.goodreads.com
-      - --postgres-host=rreading-glasses-db
-      - --postgres-database=rreading-glasses
-      - --postgres-user=rreading-glasses
-      - --postgres-password= # Generate a random string without special symbols
-      - --cookie= # Your GR cookie. Only used for GR.
       - --verbose
     restart: always
+    environment:
+      COOKIE: # Your GR cookie. Only used for GR.
+      POSTGRES_HOST: rreading-glasses-db
+      POSTGRES_DATABASE: rreading-glasses
+      POSTGRES_USER: rreading-glasses
+      POSTGRES_PASSWORD:  # Generate a random string without special symbols
     ports:
       - "8788:8788"
 

--- a/docker-compose-hardcover.yml
+++ b/docker-compose-hardcover.yml
@@ -11,13 +11,14 @@ services:
     entrypoint: ["/main", "serve"]
     command:
       - --upstream=hardcover.app
-      - --postgres-host=rreading-glasses-db
-      - --postgres-database=rreading-glasses
-      - --postgres-user=rreading-glasses
-      - --postgres-password= # Generate a random string without special symbols
-      - --hardcover-auth= # Only used for Hardcover. Starts with Bearer
       - --verbose      
     restart: unless-stopped
+    environment:
+      HARDCOVER_AUTH: # Only used for Hardcover. Starts with Bearer
+      POSTGRES_HOST: rreading-glasses-db
+      POSTGRES_DATABASE: rreading-glasses
+      POSTGRES_USER: rreading-glasses
+      POSTGRES_PASSWORD:  # Generate a random string without special symbols
     ports:
       - "8788:8788"
 


### PR DESCRIPTION
Thanks for the pointers, I was able to test the server's locally and ran them using file and inline secrets.

One thing that I could not figure out is that there is a new line character at the end whenever `filecontent` is used. I have confirmed the files I was using did not have any new line at the end, even did a `echo passwd > file` and it still had a new line in the code. I am using `go version go1.24.2 darwin/arm64`.  This behavior seems weird that it feels like i am doing something wrong :).

Also updated the sample docker files to use environment variables instead of command arguments.

edit: forgot to add vscode + copilot also helped me with this.

Fixes #119.