### PR TITLE
Start automatically populating some editions

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,8 @@ limitations and can be changed, so I'm eager to hear if people think these are
 an improvement or if it would be better to match the official behavior more
 exactly.
 
-- Titles no longer automatically include subtitles _unless_ multiple books have
-  the same primary title (as is often the case with series). This de-clutters
+- Titles no longer automatically include subtitles _unless_ it's part of a
+  series, or if multiple books have the same primary title. This de-clutters
   the UI, cleans up the directory layout, and improves import matching but
   __you may need to re-import some works with long subtitles__. I think the
   trade-off is worth it but others might disagree — let me know!

--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,11 @@ require (
 	github.com/rogpeppe/go-internal v1.13.1 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/crypto v0.38.0 // indirect
+	golang.org/x/mod v0.21.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
+	golang.org/x/tools v0.25.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+tool go.uber.org/mock/mockgen

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,8 @@ golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.15.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/mod v0.21.0 h1:vvrHzRwRfVKSiLrG+d4FMl/Qi4ukBCE6kZlTUkDYRT0=
+golang.org/x/mod v0.21.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
@@ -186,6 +188,8 @@ golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/tools v0.13.0/go.mod h1:HvlwmtVNQAhOuCjW7xxvovg8wbNq7LwfXh/k7wXUl58=
 golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=
+golang.org/x/tools v0.25.0 h1:oFU9pkj/iJgs+0DT+VMHrx+oBKs/LJMV+Uvg78sl+fE=
+golang.org/x/tools v0.25.0/go.mod h1:/vtpO8WL1N9cQC3FN5zPqb//fRXskFHbLKk4OW1Q7rg=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=

--- a/gr/generated.go
+++ b/gr/generated.go
@@ -290,13 +290,11 @@ func (v *GetBookGetBookByLegacyIdBookDetails) GetPublicationTime() float64 { ret
 
 // GetBookGetBookByLegacyIdBookDetailsLanguage includes the requested fields of the GraphQL type Language.
 type GetBookGetBookByLegacyIdBookDetailsLanguage struct {
-	IsoLanguageCode string `json:"isoLanguageCode"`
+	Name string `json:"name"`
 }
 
-// GetIsoLanguageCode returns GetBookGetBookByLegacyIdBookDetailsLanguage.IsoLanguageCode, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBookDetailsLanguage) GetIsoLanguageCode() string {
-	return v.IsoLanguageCode
-}
+// GetName returns GetBookGetBookByLegacyIdBookDetailsLanguage.Name, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBookDetailsLanguage) GetName() string { return v.Name }
 
 // GetBookGetBookByLegacyIdBookPrimaryContributorEdgeBookContributorEdge includes the requested fields of the GraphQL type BookContributorEdge.
 type GetBookGetBookByLegacyIdBookPrimaryContributorEdgeBookContributorEdge struct {
@@ -482,12 +480,12 @@ func (v *GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNo
 
 // GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetailsLanguage includes the requested fields of the GraphQL type Language.
 type GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetailsLanguage struct {
-	IsoLanguageCode string `json:"isoLanguageCode"`
+	Name string `json:"name"`
 }
 
-// GetIsoLanguageCode returns GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetailsLanguage.IsoLanguageCode, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetailsLanguage) GetIsoLanguageCode() string {
-	return v.IsoLanguageCode
+// GetName returns GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetailsLanguage.Name, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetailsLanguage) GetName() string {
+	return v.Name
 }
 
 // GetBookResponse is returned by GetBook on success.
@@ -703,7 +701,7 @@ query GetBook ($legacyId: Int!) {
 			format
 			numPages
 			language {
-				isoLanguageCode
+				name
 			}
 			officialUrl
 			publisher
@@ -747,7 +745,7 @@ query GetBook ($legacyId: Int!) {
 						title
 						details {
 							language {
-								isoLanguageCode
+								name
 							}
 						}
 					}

--- a/gr/generated.go
+++ b/gr/generated.go
@@ -448,12 +448,44 @@ func (v *GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdge) 
 
 // GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook includes the requested fields of the GraphQL type Book.
 type GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook struct {
-	LegacyId int64 `json:"legacyId"`
+	LegacyId int64                                                                                `json:"legacyId"`
+	Title    string                                                                               `json:"title"`
+	Details  GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetails `json:"details"`
 }
 
 // GetLegacyId returns GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook.LegacyId, and is useful for accessing the field via an interface.
 func (v *GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook) GetLegacyId() int64 {
 	return v.LegacyId
+}
+
+// GetTitle returns GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook.Title, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook) GetTitle() string {
+	return v.Title
+}
+
+// GetDetails returns GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook.Details, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook) GetDetails() GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetails {
+	return v.Details
+}
+
+// GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetails includes the requested fields of the GraphQL type BookDetails.
+type GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetails struct {
+	Language GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetailsLanguage `json:"language"`
+}
+
+// GetLanguage returns GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetails.Language, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetails) GetLanguage() GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetailsLanguage {
+	return v.Language
+}
+
+// GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetailsLanguage includes the requested fields of the GraphQL type Language.
+type GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetailsLanguage struct {
+	Name string `json:"name"`
+}
+
+// GetName returns GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetailsLanguage.Name, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetailsLanguage) GetName() string {
+	return v.Name
 }
 
 // GetBookResponse is returned by GetBook on success.
@@ -710,6 +742,12 @@ query GetBook ($legacyId: Int!) {
 				edges {
 					node {
 						legacyId
+						title
+						details {
+							language {
+								name
+							}
+						}
 					}
 				}
 			}

--- a/gr/generated.go
+++ b/gr/generated.go
@@ -368,10 +368,11 @@ func (v *GetBookGetBookByLegacyIdBookStatsBookOrWorkStats) GetRatingsSum() int64
 
 // GetBookGetBookByLegacyIdBookWork includes the requested fields of the GraphQL type Work.
 type GetBookGetBookByLegacyIdBookWork struct {
-	Id       string                                   `json:"id"`
-	LegacyId int64                                    `json:"legacyId"`
-	Details  GetBookGetBookByLegacyIdBookWorkDetails  `json:"details"`
-	BestBook GetBookGetBookByLegacyIdBookWorkBestBook `json:"bestBook"`
+	Id       string                                                  `json:"id"`
+	LegacyId int64                                                   `json:"legacyId"`
+	Details  GetBookGetBookByLegacyIdBookWorkDetails                 `json:"details"`
+	BestBook GetBookGetBookByLegacyIdBookWorkBestBook                `json:"bestBook"`
+	Editions GetBookGetBookByLegacyIdBookWorkEditionsBooksConnection `json:"editions"`
 }
 
 // GetId returns GetBookGetBookByLegacyIdBookWork.Id, and is useful for accessing the field via an interface.
@@ -388,6 +389,11 @@ func (v *GetBookGetBookByLegacyIdBookWork) GetDetails() GetBookGetBookByLegacyId
 // GetBestBook returns GetBookGetBookByLegacyIdBookWork.BestBook, and is useful for accessing the field via an interface.
 func (v *GetBookGetBookByLegacyIdBookWork) GetBestBook() GetBookGetBookByLegacyIdBookWorkBestBook {
 	return v.BestBook
+}
+
+// GetEditions returns GetBookGetBookByLegacyIdBookWork.Editions, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBookWork) GetEditions() GetBookGetBookByLegacyIdBookWorkEditionsBooksConnection {
+	return v.Editions
 }
 
 // GetBookGetBookByLegacyIdBookWorkBestBook includes the requested fields of the GraphQL type Book.
@@ -418,6 +424,36 @@ func (v *GetBookGetBookByLegacyIdBookWorkDetails) GetWebUrl() string { return v.
 // GetPublicationTime returns GetBookGetBookByLegacyIdBookWorkDetails.PublicationTime, and is useful for accessing the field via an interface.
 func (v *GetBookGetBookByLegacyIdBookWorkDetails) GetPublicationTime() float64 {
 	return v.PublicationTime
+}
+
+// GetBookGetBookByLegacyIdBookWorkEditionsBooksConnection includes the requested fields of the GraphQL type BooksConnection.
+type GetBookGetBookByLegacyIdBookWorkEditionsBooksConnection struct {
+	Edges []GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdge `json:"edges"`
+}
+
+// GetEdges returns GetBookGetBookByLegacyIdBookWorkEditionsBooksConnection.Edges, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBookWorkEditionsBooksConnection) GetEdges() []GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdge {
+	return v.Edges
+}
+
+// GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdge includes the requested fields of the GraphQL type BooksEdge.
+type GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdge struct {
+	Node GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook `json:"node"`
+}
+
+// GetNode returns GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdge.Node, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdge) GetNode() GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook {
+	return v.Node
+}
+
+// GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook includes the requested fields of the GraphQL type Book.
+type GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook struct {
+	LegacyId int64 `json:"legacyId"`
+}
+
+// GetLegacyId returns GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook.LegacyId, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook) GetLegacyId() int64 {
+	return v.LegacyId
 }
 
 // GetBookResponse is returned by GetBook on success.
@@ -669,6 +705,13 @@ query GetBook ($legacyId: Int!) {
 				legacyId
 				title
 				titlePrimary
+			}
+			editions {
+				edges {
+					node {
+						legacyId
+					}
+				}
 			}
 		}
 	}

--- a/gr/generated.go
+++ b/gr/generated.go
@@ -290,11 +290,13 @@ func (v *GetBookGetBookByLegacyIdBookDetails) GetPublicationTime() float64 { ret
 
 // GetBookGetBookByLegacyIdBookDetailsLanguage includes the requested fields of the GraphQL type Language.
 type GetBookGetBookByLegacyIdBookDetailsLanguage struct {
-	Name string `json:"name"`
+	IsoLanguageCode string `json:"isoLanguageCode"`
 }
 
-// GetName returns GetBookGetBookByLegacyIdBookDetailsLanguage.Name, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBookDetailsLanguage) GetName() string { return v.Name }
+// GetIsoLanguageCode returns GetBookGetBookByLegacyIdBookDetailsLanguage.IsoLanguageCode, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBookDetailsLanguage) GetIsoLanguageCode() string {
+	return v.IsoLanguageCode
+}
 
 // GetBookGetBookByLegacyIdBookPrimaryContributorEdgeBookContributorEdge includes the requested fields of the GraphQL type BookContributorEdge.
 type GetBookGetBookByLegacyIdBookPrimaryContributorEdgeBookContributorEdge struct {
@@ -480,12 +482,12 @@ func (v *GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNo
 
 // GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetailsLanguage includes the requested fields of the GraphQL type Language.
 type GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetailsLanguage struct {
-	Name string `json:"name"`
+	IsoLanguageCode string `json:"isoLanguageCode"`
 }
 
-// GetName returns GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetailsLanguage.Name, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetailsLanguage) GetName() string {
-	return v.Name
+// GetIsoLanguageCode returns GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetailsLanguage.IsoLanguageCode, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetailsLanguage) GetIsoLanguageCode() string {
+	return v.IsoLanguageCode
 }
 
 // GetBookResponse is returned by GetBook on success.
@@ -701,7 +703,7 @@ query GetBook ($legacyId: Int!) {
 			format
 			numPages
 			language {
-				name
+				isoLanguageCode
 			}
 			officialUrl
 			publisher
@@ -745,7 +747,7 @@ query GetBook ($legacyId: Int!) {
 						title
 						details {
 							language {
-								name
+								isoLanguageCode
 							}
 						}
 					}

--- a/gr/queries.graphql
+++ b/gr/queries.graphql
@@ -64,6 +64,12 @@ query GetBook($legacyId: Int!) {
         edges {
           node {
             legacyId
+            title
+            details {
+              language {
+                name
+              }
+            }
           }
         }
       }

--- a/gr/queries.graphql
+++ b/gr/queries.graphql
@@ -22,7 +22,7 @@ query GetBook($legacyId: Int!) {
       format
       numPages
       language {
-        isoLanguageCode
+        name
       }
       officialUrl
       publisher
@@ -67,7 +67,7 @@ query GetBook($legacyId: Int!) {
             title
             details {
               language {
-                isoLanguageCode
+                name
               }
             }
           }

--- a/gr/queries.graphql
+++ b/gr/queries.graphql
@@ -22,7 +22,7 @@ query GetBook($legacyId: Int!) {
       format
       numPages
       language {
-        name
+        isoLanguageCode
       }
       officialUrl
       publisher
@@ -67,7 +67,7 @@ query GetBook($legacyId: Int!) {
             title
             details {
               language {
-                name
+                isoLanguageCode
               }
             }
           }

--- a/gr/queries.graphql
+++ b/gr/queries.graphql
@@ -47,6 +47,7 @@ query GetBook($legacyId: Int!) {
     title
     titlePrimary
     webUrl
+
     work {
       id
       legacyId
@@ -58,6 +59,13 @@ query GetBook($legacyId: Int!) {
         legacyId
         title
         titlePrimary
+      }
+      editions {
+        edges {
+          node {
+            legacyId
+          }
+        }
       }
     }
   }

--- a/internal/controller_test.go
+++ b/internal/controller_test.go
@@ -61,7 +61,7 @@ func TestIncrementalDenormalization(t *testing.T) {
 		return initialAuthorBytes, nil
 	}).AnyTimes()
 
-	getter.EXPECT().GetBook(gomock.Any(), englishEdition.ForeignID).DoAndReturn(func(ctx context.Context, bookID int64) ([]byte, int64, int64, error) {
+	getter.EXPECT().GetBook(gomock.Any(), englishEdition.ForeignID, nil).DoAndReturn(func(ctx context.Context, bookID int64, loadEditions editionsCallback) ([]byte, int64, int64, error) {
 		cachedBytes, ok := ctrl.cache.Get(ctx, BookKey(bookID))
 		if ok {
 			return cachedBytes, 0, 0, nil
@@ -69,7 +69,7 @@ func TestIncrementalDenormalization(t *testing.T) {
 		return englishEditionBytes, work.ForeignID, authorID, nil
 	}).AnyTimes()
 
-	getter.EXPECT().GetBook(gomock.Any(), frenchEdition.ForeignID).DoAndReturn(func(ctx context.Context, bookID int64) ([]byte, int64, int64, error) {
+	getter.EXPECT().GetBook(gomock.Any(), frenchEdition.ForeignID, nil).DoAndReturn(func(ctx context.Context, bookID int64, loadEditions editionsCallback) ([]byte, int64, int64, error) {
 		cachedBytes, ok := ctrl.cache.Get(ctx, BookKey(bookID))
 		if ok {
 			return cachedBytes, 0, 0, nil
@@ -77,7 +77,7 @@ func TestIncrementalDenormalization(t *testing.T) {
 		return frenchEditionBytes, work.ForeignID, authorID, nil
 	}).AnyTimes()
 
-	getter.EXPECT().GetWork(gomock.Any(), work.ForeignID).DoAndReturn(func(ctx context.Context, workID int64) ([]byte, int64, error) {
+	getter.EXPECT().GetWork(gomock.Any(), work.ForeignID, nil).DoAndReturn(func(ctx context.Context, workID int64, loadEditions editionsCallback) ([]byte, int64, error) {
 		cachedBytes, ok := ctrl.cache.Get(ctx, WorkKey(workID))
 		if ok {
 			return cachedBytes, 0, nil
@@ -166,7 +166,7 @@ func TestDenormalizeMissing(t *testing.T) {
 
 	notFoundGetter := NewMockgetter(gomock.NewController(t))
 	notFoundGetter.EXPECT().GetAuthor(gomock.Any(), authorID).Return(nil, errNotFound).AnyTimes()
-	notFoundGetter.EXPECT().GetWork(gomock.Any(), workID).Return(nil, 0, errNotFound).AnyTimes()
+	notFoundGetter.EXPECT().GetWork(gomock.Any(), workID, nil).Return(nil, 0, errNotFound).AnyTimes()
 
 	ctrl, err := NewController(cache, notFoundGetter)
 	require.NoError(t, err)
@@ -179,7 +179,8 @@ func TestDenormalizeMissing(t *testing.T) {
 }
 
 func TestSubtitles(t *testing.T) {
-	// Subtitles (i.e. FullTitle) are used in situations where multiple works share the same primary title.
+	// Subtitles (i.e. FullTitle) are used in situations where multiple works
+	// share the same primary title, or when the work belongs to a series..
 
 	t.Parallel()
 
@@ -297,7 +298,7 @@ func TestSubtitles(t *testing.T) {
 		return initialAuthorBytes, nil
 	}).AnyTimes()
 
-	getter.EXPECT().GetWork(gomock.Any(), workDupe1.ForeignID).DoAndReturn(func(ctx context.Context, workID int64) ([]byte, int64, error) {
+	getter.EXPECT().GetWork(gomock.Any(), workDupe1.ForeignID, nil).DoAndReturn(func(ctx context.Context, workID int64, loadEditions editionsCallback) ([]byte, int64, error) {
 		cachedBytes, ok := ctrl.cache.Get(ctx, WorkKey(workID))
 		if ok {
 			return cachedBytes, 0, nil
@@ -305,7 +306,7 @@ func TestSubtitles(t *testing.T) {
 		return initialWorkDupe1Bytes, author.ForeignID, nil
 	}).AnyTimes()
 
-	getter.EXPECT().GetWork(gomock.Any(), workDupe2.ForeignID).DoAndReturn(func(ctx context.Context, workID int64) ([]byte, int64, error) {
+	getter.EXPECT().GetWork(gomock.Any(), workDupe2.ForeignID, nil).DoAndReturn(func(ctx context.Context, workID int64, loadEditions editionsCallback) ([]byte, int64, error) {
 		cachedBytes, ok := ctrl.cache.Get(ctx, WorkKey(workID))
 		if ok {
 			return cachedBytes, 0, nil
@@ -313,7 +314,7 @@ func TestSubtitles(t *testing.T) {
 		return initialWorkDupe2Bytes, author.ForeignID, nil
 	}).AnyTimes()
 
-	getter.EXPECT().GetWork(gomock.Any(), workDupe3.ForeignID).DoAndReturn(func(ctx context.Context, workID int64) ([]byte, int64, error) {
+	getter.EXPECT().GetWork(gomock.Any(), workDupe3.ForeignID, nil).DoAndReturn(func(ctx context.Context, workID int64, loadEditions editionsCallback) ([]byte, int64, error) {
 		cachedBytes, ok := ctrl.cache.Get(ctx, WorkKey(workID))
 		if ok {
 			return cachedBytes, 0, nil
@@ -321,7 +322,7 @@ func TestSubtitles(t *testing.T) {
 		return initialWorkDupe3Bytes, author.ForeignID, nil
 	}).AnyTimes()
 
-	getter.EXPECT().GetWork(gomock.Any(), workDupe4.ForeignID).DoAndReturn(func(ctx context.Context, workID int64) ([]byte, int64, error) {
+	getter.EXPECT().GetWork(gomock.Any(), workDupe4.ForeignID, nil).DoAndReturn(func(ctx context.Context, workID int64, loadEditions editionsCallback) ([]byte, int64, error) {
 		cachedBytes, ok := ctrl.cache.Get(ctx, WorkKey(workID))
 		if ok {
 			return cachedBytes, 0, nil
@@ -329,7 +330,7 @@ func TestSubtitles(t *testing.T) {
 		return initialWorkDupe4Bytes, author.ForeignID, nil
 	}).AnyTimes()
 
-	getter.EXPECT().GetWork(gomock.Any(), workUnique.ForeignID).DoAndReturn(func(ctx context.Context, workID int64) ([]byte, int64, error) {
+	getter.EXPECT().GetWork(gomock.Any(), workUnique.ForeignID, nil).DoAndReturn(func(ctx context.Context, workID int64, loadEditions editionsCallback) ([]byte, int64, error) {
 		cachedBytes, ok := ctrl.cache.Get(ctx, WorkKey(workID))
 		if ok {
 			return cachedBytes, 0, nil
@@ -337,7 +338,7 @@ func TestSubtitles(t *testing.T) {
 		return initialWorkUniqueBytes, author.ForeignID, nil
 	}).AnyTimes()
 
-	getter.EXPECT().GetWork(gomock.Any(), workSeries.ForeignID).DoAndReturn(func(ctx context.Context, workID int64) ([]byte, int64, error) {
+	getter.EXPECT().GetWork(gomock.Any(), workSeries.ForeignID, nil).DoAndReturn(func(ctx context.Context, workID int64, loadEditions editionsCallback) ([]byte, int64, error) {
 		cachedBytes, ok := ctrl.cache.Get(ctx, WorkKey(workID))
 		if ok {
 			return cachedBytes, 0, nil
@@ -409,7 +410,7 @@ func TestSortedInvariant(t *testing.T) {
 			},
 		}
 
-		getter.EXPECT().GetWork(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, id int64) ([]byte, int64, error) {
+		getter.EXPECT().GetWork(gomock.Any(), gomock.Any(), nil).DoAndReturn(func(ctx context.Context, id int64, loadEditions editionsCallback) ([]byte, int64, error) {
 			bytes, err := json.Marshal(workResource{ForeignID: id, Books: []bookResource{{}}})
 			return bytes, 0, err
 		}).AnyTimes()
@@ -450,12 +451,12 @@ func TestSortedInvariant(t *testing.T) {
 			},
 		}
 
-		getter.EXPECT().GetWork(gomock.Any(), work.ForeignID).DoAndReturn(func(ctx context.Context, id int64) ([]byte, int64, error) {
+		getter.EXPECT().GetWork(gomock.Any(), work.ForeignID, nil).DoAndReturn(func(ctx context.Context, id int64, loadEditions editionsCallback) ([]byte, int64, error) {
 			workBytes, err := json.Marshal(work)
 			return workBytes, 0, err
 		})
 
-		getter.EXPECT().GetBook(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, id int64) ([]byte, int64, int64, error) {
+		getter.EXPECT().GetBook(gomock.Any(), gomock.Any(), nil).DoAndReturn(func(ctx context.Context, id int64, loadEditions editionsCallback) ([]byte, int64, int64, error) {
 			bytes, err := json.Marshal(workResource{ForeignID: work.ForeignID, Books: []bookResource{{ForeignID: id}}})
 			return bytes, 0, 0, err
 		}).AnyTimes()

--- a/internal/gr.go
+++ b/internal/gr.go
@@ -56,9 +56,11 @@ func NewGRGQL(ctx context.Context, upstream *http.Client, cookie string) (graphq
 	}
 
 	auth := &HeaderTransport{
-		Key:          "X-Api-Key",
-		Value:        string(defaultToken),
-		RoundTripper: http.DefaultTransport,
+		Key:   "X-Api-Key",
+		Value: string(defaultToken),
+		RoundTripper: errorProxyTransport{
+			RoundTripper: http.DefaultTransport,
+		},
 	}
 	rate := time.Second / 3.0 // 3RPS seems to be the limit for all gql traffic, regardless of credentials.
 

--- a/internal/gr.go
+++ b/internal/gr.go
@@ -195,7 +195,7 @@ func (g *GRGetter) GetBook(ctx context.Context, bookID int64, loadEditions editi
 		Title:              book.TitlePrimary,
 		FullTitle:          book.Title,
 		ShortTitle:         book.TitlePrimary,
-		Language:           book.Details.Language.Name,
+		Language:           book.Details.Language.IsoLanguageCode,
 		Format:             book.Details.Format,
 		EditionInformation: "",                     // TODO: Is this used anywhere?
 		Publisher:          book.Details.Publisher, // TODO: Ignore books without publishers?
@@ -276,7 +276,7 @@ func (g *GRGetter) GetBook(ctx context.Context, bookID int64, loadEditions editi
 	if loadEditions != nil && workRsc.BestBookID == bookID {
 		editions := map[editionDedupe]int64{}
 		for _, e := range resp.GetBookByLegacyId.Work.Editions.Edges {
-			key := editionDedupe{title: strings.ToUpper(e.Node.Title), language: e.Node.Details.Language.Name}
+			key := editionDedupe{title: strings.ToUpper(e.Node.Title), language: e.Node.Details.Language.IsoLanguageCode}
 			if _, ok := editions[key]; ok {
 				continue // Already saw an edition similar to this one.
 			}

--- a/internal/gr.go
+++ b/internal/gr.go
@@ -197,7 +197,7 @@ func (g *GRGetter) GetBook(ctx context.Context, bookID int64, loadEditions editi
 		Title:              book.TitlePrimary,
 		FullTitle:          book.Title,
 		ShortTitle:         book.TitlePrimary,
-		Language:           book.Details.Language.IsoLanguageCode,
+		Language:           book.Details.Language.Name,
 		Format:             book.Details.Format,
 		EditionInformation: "",                     // TODO: Is this used anywhere?
 		Publisher:          book.Details.Publisher, // TODO: Ignore books without publishers?
@@ -278,7 +278,7 @@ func (g *GRGetter) GetBook(ctx context.Context, bookID int64, loadEditions editi
 	if loadEditions != nil && workRsc.BestBookID == bookID {
 		editions := map[editionDedupe]int64{}
 		for _, e := range resp.GetBookByLegacyId.Work.Editions.Edges {
-			key := editionDedupe{title: strings.ToUpper(e.Node.Title), language: e.Node.Details.Language.IsoLanguageCode}
+			key := editionDedupe{title: strings.ToUpper(e.Node.Title), language: e.Node.Details.Language.Name}
 			if _, ok := editions[key]; ok {
 				continue // Already saw an edition similar to this one.
 			}

--- a/internal/gr.go
+++ b/internal/gr.go
@@ -197,7 +197,7 @@ func (g *GRGetter) GetBook(ctx context.Context, bookID int64, loadEditions editi
 		Title:              book.TitlePrimary,
 		FullTitle:          book.Title,
 		ShortTitle:         book.TitlePrimary,
-		Language:           book.Details.Language.Name,
+		Language:           iso639_3(book.Details.Language.Name),
 		Format:             book.Details.Format,
 		EditionInformation: "",                     // TODO: Is this used anywhere?
 		Publisher:          book.Details.Publisher, // TODO: Ignore books without publishers?
@@ -278,7 +278,7 @@ func (g *GRGetter) GetBook(ctx context.Context, bookID int64, loadEditions editi
 	if loadEditions != nil && workRsc.BestBookID == bookID {
 		editions := map[editionDedupe]int64{}
 		for _, e := range resp.GetBookByLegacyId.Work.Editions.Edges {
-			key := editionDedupe{title: strings.ToUpper(e.Node.Title), language: e.Node.Details.Language.Name}
+			key := editionDedupe{title: strings.ToUpper(e.Node.Title), language: iso639_3(e.Node.Details.Language.Name)}
 			if _, ok := editions[key]; ok {
 				continue // Already saw an edition similar to this one.
 			}

--- a/internal/gr.go
+++ b/internal/gr.go
@@ -7,7 +7,9 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"maps"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -95,7 +97,7 @@ func NewGRGQL(ctx context.Context, upstream *http.Client, cookie string) (graphq
 
 // GetWork returns a work with all known editions. Due to the way R—— works, if
 // an edition is missing here (like a translated edition) it's not fetchable.
-func (g *GRGetter) GetWork(ctx context.Context, workID int64) (_ []byte, authorID int64, _ error) {
+func (g *GRGetter) GetWork(ctx context.Context, workID int64, loadEditions editionsCallback) (_ []byte, authorID int64, _ error) {
 	if workID == 146797269 {
 		// This work always 500s for some reason. Ignore it.
 		return nil, 0, errNotFound
@@ -111,7 +113,7 @@ func (g *GRGetter) GetWork(ctx context.Context, workID int64) (_ []byte, authorI
 
 		bookID := work.BestBookID
 		if bookID != 0 {
-			out, _, authorID, err := g.GetBook(ctx, bookID)
+			out, _, authorID, err := g.GetBook(ctx, bookID, loadEditions)
 			return out, authorID, err
 		}
 	}
@@ -135,13 +137,13 @@ func (g *GRGetter) GetWork(ctx context.Context, workID int64) (_ []byte, authorI
 
 	Log(ctx).Debug("getting book", "bookID", bookID)
 
-	out, _, authorID, err := g.GetBook(ctx, bookID)
+	out, _, authorID, err := g.GetBook(ctx, bookID, loadEditions)
 	return out, authorID, err
 }
 
 // GetBook fetches a book (edition) from GR.
-func (g *GRGetter) GetBook(ctx context.Context, bookID int64) (_ []byte, workID, authorID int64, _ error) {
-	if workBytes, ttl, ok := g.cache.GetWithTTL(ctx, BookKey(bookID)); ok && ttl > 0 {
+func (g *GRGetter) GetBook(ctx context.Context, bookID int64, loadEditions editionsCallback) (_ []byte, workID, authorID int64, _ error) {
+	if workBytes, ttl, ok := g.cache.GetWithTTL(ctx, BookKey(bookID)); ok && ttl > 0 && loadEditions == nil {
 		return workBytes, 0, 0, nil
 	}
 
@@ -269,6 +271,20 @@ func (g *GRGetter) GetBook(ctx context.Context, bookID int64) (_ []byte, workID,
 		g.cache.Set(ctx, WorkKey(workRsc.ForeignID), out, _workTTL)
 	}
 
+	// If this is the "best" edition for the work, load some additional
+	// editions for it.
+	if loadEditions != nil && workRsc.BestBookID == bookID {
+		editions := map[editionDedupe]int64{}
+		for _, e := range resp.GetBookByLegacyId.Work.Editions.Edges {
+			key := editionDedupe{title: strings.ToUpper(e.Node.Title), language: e.Node.Details.Language.Name}
+			if _, ok := editions[key]; ok {
+				continue // Already saw an edition similar to this one.
+			}
+			editions[key] = e.Node.LegacyId
+		}
+		loadEditions(slices.Collect(maps.Values(editions))...)
+	}
+
 	return out, workRsc.ForeignID, authorRsc.ForeignID, nil
 }
 
@@ -323,7 +339,7 @@ func (g *GRGetter) GetAuthor(ctx context.Context, authorID int64) ([]byte, error
 	// Load books until we find one with our author.
 	for _, e := range works.GetWorksByContributor.Edges {
 		id := e.Node.BestBook.LegacyId
-		workBytes, _, _, err := g.GetBook(ctx, id)
+		workBytes, _, _, err := g.GetBook(ctx, id, nil)
 		if err != nil {
 			Log(ctx).Warn("problem getting initial book for author", "err", err, "bookID", id, "authorID", authorID)
 			continue
@@ -429,7 +445,7 @@ func (g *GRGetter) legacyAuthorIDtoKCA(ctx context.Context, authorID int64) (str
 		return "", err
 	}
 
-	workBytes, _, _, err := g.GetBook(ctx, bookID)
+	workBytes, _, _, err := g.GetBook(ctx, bookID, nil)
 	if err != nil {
 		Log(ctx).Warn("problem getting book for author ID lookup", "err", err, "bookID", bookID)
 		return "", err
@@ -481,4 +497,12 @@ func releaseDate(t float64) string {
 	}
 
 	return ts.Format(time.DateTime)
+}
+
+// editionDedupe is how we avoid grabbing unnecessary editions. If we've
+// already seen an edition with the same title and language, then we don't need
+// any more for the same title and language.
+type editionDedupe struct {
+	title    string
+	language string
 }

--- a/internal/gr_test.go
+++ b/internal/gr_test.go
@@ -98,7 +98,7 @@ func TestGRGetBookDataIntegrity(t *testing.T) {
 						Format:   "Hardcover",
 						NumPages: 295,
 						Language: gr.GetBookGetBookByLegacyIdBookDetailsLanguage{
-							IsoLanguageCode: "eng",
+							Name: "English",
 						},
 						OfficialUrl:     "",
 						Publisher:       "Atheneum Books for Young Readers",
@@ -141,7 +141,7 @@ func TestGRGetBookDataIntegrity(t *testing.T) {
 										Title:    "Out of My Mind",
 										Details: gr.GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetails{
 											Language: gr.GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetailsLanguage{
-												IsoLanguageCode: "eng",
+												Name: "english",
 											},
 										},
 									},
@@ -152,7 +152,7 @@ func TestGRGetBookDataIntegrity(t *testing.T) {
 										Title:    "OUT OF MY MIND",
 										Details: gr.GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetails{
 											Language: gr.GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetailsLanguage{
-												IsoLanguageCode: "eng",
+												Name: "english",
 											},
 										},
 									},

--- a/internal/gr_test.go
+++ b/internal/gr_test.go
@@ -98,7 +98,7 @@ func TestGRGetBookDataIntegrity(t *testing.T) {
 						Format:   "Hardcover",
 						NumPages: 295,
 						Language: gr.GetBookGetBookByLegacyIdBookDetailsLanguage{
-							Name: "English",
+							IsoLanguageCode: "eng",
 						},
 						OfficialUrl:     "",
 						Publisher:       "Atheneum Books for Young Readers",
@@ -141,7 +141,7 @@ func TestGRGetBookDataIntegrity(t *testing.T) {
 										Title:    "Out of My Mind",
 										Details: gr.GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetails{
 											Language: gr.GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetailsLanguage{
-												Name: "english",
+												IsoLanguageCode: "eng",
 											},
 										},
 									},
@@ -152,7 +152,7 @@ func TestGRGetBookDataIntegrity(t *testing.T) {
 										Title:    "OUT OF MY MIND",
 										Details: gr.GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetails{
 											Language: gr.GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetailsLanguage{
-												Name: "english",
+												IsoLanguageCode: "eng",
 											},
 										},
 									},

--- a/internal/language.go
+++ b/internal/language.go
@@ -1,0 +1,41 @@
+package internal
+
+var _codes = map[string]string{
+	"English":          "eng",
+	"French":           "fra",
+	"Spanish":          "spa",
+	"German":           "deu",
+	"Italian":          "ita",
+	"Danish":           "dan",
+	"Dutch":            "nld",
+	"Japanese":         "jpn",
+	"Icelandic":        "isl",
+	"Chinese":          "zho",
+	"Russian":          "rus",
+	"Polish":           "pol",
+	"Vietnamese":       "vie",
+	"Swedish":          "swe",
+	"Norwegian":        "nor",
+	"Norwegian Bokmal": "nob",
+	"Finnish":          "fin",
+	"Turkish":          "tur",
+	"Portuguese":       "por",
+	"Greek":            "ell",
+	"Korean":           "kor",
+	"Hungarian":        "hun",
+	"Hebrew":           "heb",
+	"Czech":            "ces",
+	"Hindi":            "hin",
+	"Thai":             "tha",
+	"Bulgarian":        "bul",
+	"Romanian":         "ron",
+	"Arabic":           "ara",
+}
+
+func iso639_3(name string) (iso string) {
+	iso, ok := _codes[name]
+	if ok {
+		return iso
+	}
+	return name
+}

--- a/internal/mock.go
+++ b/internal/mock.go
@@ -118,9 +118,9 @@ func (c *MockgetterGetAuthorBooksCall) DoAndReturn(f func(context.Context, int64
 }
 
 // GetBook mocks base method.
-func (m *Mockgetter) GetBook(ctx context.Context, bookID int64) ([]byte, int64, int64, error) {
+func (m *Mockgetter) GetBook(ctx context.Context, bookID int64, loadEditions editionsCallback) ([]byte, int64, int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBook", ctx, bookID)
+	ret := m.ctrl.Call(m, "GetBook", ctx, bookID, loadEditions)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(int64)
 	ret2, _ := ret[2].(int64)
@@ -129,9 +129,9 @@ func (m *Mockgetter) GetBook(ctx context.Context, bookID int64) ([]byte, int64, 
 }
 
 // GetBook indicates an expected call of GetBook.
-func (mr *MockgetterMockRecorder) GetBook(ctx, bookID any) *MockgetterGetBookCall {
+func (mr *MockgetterMockRecorder) GetBook(ctx, bookID, loadEditions any) *MockgetterGetBookCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBook", reflect.TypeOf((*Mockgetter)(nil).GetBook), ctx, bookID)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBook", reflect.TypeOf((*Mockgetter)(nil).GetBook), ctx, bookID, loadEditions)
 	return &MockgetterGetBookCall{Call: call}
 }
 
@@ -147,21 +147,21 @@ func (c *MockgetterGetBookCall) Return(arg0 []byte, workID, authorID int64, arg3
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockgetterGetBookCall) Do(f func(context.Context, int64) ([]byte, int64, int64, error)) *MockgetterGetBookCall {
+func (c *MockgetterGetBookCall) Do(f func(context.Context, int64, editionsCallback) ([]byte, int64, int64, error)) *MockgetterGetBookCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockgetterGetBookCall) DoAndReturn(f func(context.Context, int64) ([]byte, int64, int64, error)) *MockgetterGetBookCall {
+func (c *MockgetterGetBookCall) DoAndReturn(f func(context.Context, int64, editionsCallback) ([]byte, int64, int64, error)) *MockgetterGetBookCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetWork mocks base method.
-func (m *Mockgetter) GetWork(ctx context.Context, workID int64) ([]byte, int64, error) {
+func (m *Mockgetter) GetWork(ctx context.Context, workID int64, loadEditions editionsCallback) ([]byte, int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetWork", ctx, workID)
+	ret := m.ctrl.Call(m, "GetWork", ctx, workID, loadEditions)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(int64)
 	ret2, _ := ret[2].(error)
@@ -169,9 +169,9 @@ func (m *Mockgetter) GetWork(ctx context.Context, workID int64) ([]byte, int64, 
 }
 
 // GetWork indicates an expected call of GetWork.
-func (mr *MockgetterMockRecorder) GetWork(ctx, workID any) *MockgetterGetWorkCall {
+func (mr *MockgetterMockRecorder) GetWork(ctx, workID, loadEditions any) *MockgetterGetWorkCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWork", reflect.TypeOf((*Mockgetter)(nil).GetWork), ctx, workID)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWork", reflect.TypeOf((*Mockgetter)(nil).GetWork), ctx, workID, loadEditions)
 	return &MockgetterGetWorkCall{Call: call}
 }
 
@@ -187,13 +187,13 @@ func (c *MockgetterGetWorkCall) Return(arg0 []byte, authorID int64, arg2 error) 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockgetterGetWorkCall) Do(f func(context.Context, int64) ([]byte, int64, error)) *MockgetterGetWorkCall {
+func (c *MockgetterGetWorkCall) Do(f func(context.Context, int64, editionsCallback) ([]byte, int64, error)) *MockgetterGetWorkCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockgetterGetWorkCall) DoAndReturn(f func(context.Context, int64) ([]byte, int64, error)) *MockgetterGetWorkCall {
+func (c *MockgetterGetWorkCall) DoAndReturn(f func(context.Context, int64, editionsCallback) ([]byte, int64, error)) *MockgetterGetWorkCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }


### PR DESCRIPTION
This starts automatically populating up to 20 editions per work. This happens asynchronously, so the very first time a work is fetched it will still only have the "best" edition, but subsequent fetches may include more.

We're limited to 20 right now partly because it remains to be seen what kind of impact this will have on performance, but more practically because 20 is the limit before we need to paginate and this is just easier for now.

Editions are de-duped somewhat, so for example if two editions share the same language and title we only take one. (The official server's edition selection menu can have dozens and dozens of duplicated titles which are a mess to crawl through.)

I realized I'm not returning the ISO639-3 code for language, which might impact edition selection. This might also explain why users have still had trouble picking up translated editions.

Implementation-wise I just plumbed a callback through to the getter which allows it to register some IDs for fetching. Blunt but it works. We're getting books in serial during denormalization, so there's room for improvement.

Fixes https://github.com/blampe/rreading-glasses/issues/82 with the usual caveat that caches will take a while to expire.