### PR TITLE
Clamp query batch size

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ graph LR;
 > to me directly if you have questions or need help, please don't bother the R——
 > team.
 
-As of May 2025 there are ~900 users of the shared instance. Here's what some
+As of June 2025 there are ~1400 users of the shared instance. Here's what some
 of them have said so far:
 
 > Man this is wayyyyyy better than the inhouse metadata, thank you!!

--- a/cmd/rghc/main.go
+++ b/cmd/rghc/main.go
@@ -68,7 +68,7 @@ func (s *server) Run() error {
 
 	hcClient := &http.Client{Transport: hcTransport}
 
-	gql, err := internal.NewBatchedGraphQLClient("https://api.hardcover.app/v1/graphql", hcClient, time.Second)
+	gql, err := internal.NewBatchedGraphQLClient("https://api.hardcover.app/v1/graphql", hcClient, time.Second, 20 /* Not sure about this */)
 	if err != nil {
 		return err
 	}

--- a/internal/gr.go
+++ b/internal/gr.go
@@ -63,8 +63,8 @@ func NewGRGQL(ctx context.Context, upstream *http.Client, cookie string) (graphq
 		},
 	}
 	// 3RPS seems to be the limit for all gql traffic, regardless of
-	// credentials, but still occasionally gives 403s. So let's try 2RPS.
-	rate := time.Second / 2.0
+	// credentials.
+	rate := time.Second / 3.0
 
 	// This path is disabled for now because unauth'd traffic is allowed the
 	// same RPS as auth'd. The value of the cookie then is to simply allow more

--- a/internal/gr.go
+++ b/internal/gr.go
@@ -96,7 +96,7 @@ func NewGRGQL(ctx context.Context, upstream *http.Client, cookie string) (graphq
 		}
 	*/
 
-	return NewBatchedGraphQLClient(string(host), &http.Client{Transport: auth}, rate)
+	return NewBatchedGraphQLClient(string(host), &http.Client{Transport: auth}, rate, 6 /* Confirmed empirically. */)
 }
 
 // GetWork returns a work with all known editions. Due to the way R—— works, if

--- a/internal/graphql.go
+++ b/internal/graphql.go
@@ -24,21 +24,21 @@ import (
 type batchedgqlclient struct {
 	mu sync.Mutex
 
-	subscriptions map[string]*subscription
-	qb            *queryBuilder
+	batchSize int            // batchSize is the max number of queries per batch.
+	queue     []batchedQuery // queue contains spillover in cases where we've accumulated more queries than our batch size allows.
 
 	wrapped graphql.Client
 }
 
 // NewBatchedGraphQLClient creates a batching GraphQL client. Queries are
 // accumulated and executed regularly accurding to the given rate.
-func NewBatchedGraphQLClient(url string, client *http.Client, rate time.Duration) (graphql.Client, error) {
+func NewBatchedGraphQLClient(url string, client *http.Client, rate time.Duration, batchSize int) (graphql.Client, error) {
 	wrapped := graphql.NewClient(url, client)
 
 	c := &batchedgqlclient{
-		qb:            newQueryBuilder(),
-		subscriptions: map[string]*subscription{},
-		wrapped:       wrapped,
+		batchSize: batchSize,
+		wrapped:   wrapped,
+		queue:     []batchedQuery{},
 	}
 
 	go func() {
@@ -50,16 +50,23 @@ func NewBatchedGraphQLClient(url string, client *http.Client, rate time.Duration
 	return c, nil
 }
 
-// flush executes the aggregated queries and returns responses to listeners.
+// flush pops the oldest batchedQuery off the queue and executes it.
+// Individualized errors are returned to listeners if possible, so one query
+// can fail without the entire batch failing. The whole batch can still fail in
+// other cases, e.g. 4XX response codes.
 func (c *batchedgqlclient) flush(ctx context.Context) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if c.qb.op == nil || c.qb.fields == 0 {
+	if len(c.queue) == 0 {
 		return // Nothing to do yet.
 	}
 
-	query, vars, err := c.qb.build()
+	// Take our oldest batch off the queue.
+	batch := c.queue[0]
+	c.queue = c.queue[1:]
+
+	query, vars, err := batch.qb.build()
 	if err != nil {
 		Log(ctx).Error("unable to build query", "err", err)
 		return
@@ -69,18 +76,15 @@ func (c *batchedgqlclient) flush(ctx context.Context) {
 	req := &graphql.Request{
 		Query:     query,
 		Variables: vars,
-		OpName:    c.qb.op.Name.Value,
+		OpName:    batch.qb.op.Name.Value,
 	}
 	resp := &graphql.Response{
 		Data: &data,
 	}
 
-	// Hold on to our subscribers before we reset the batcher.
-	subscriptions := c.subscriptions
-
 	// Issue the request in a separate goroutine so we can continue to
 	// accumulate queries without needing to wait for the network call.
-	go func(qb *queryBuilder) {
+	go func(batch batchedQuery) {
 		ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
 		defer cancel()
 
@@ -91,24 +95,24 @@ func (c *batchedgqlclient) flush(ctx context.Context) {
 		// it's just the wrapped version of our response errors.
 		if resp != nil && len(resp.Errors) > 0 {
 			for _, e := range resp.Errors {
-				sub, ok := subscriptions[e.Path.String()]
+				sub, ok := batch.subscribers[e.Path.String()]
 				if !ok {
 					continue
 				}
 				sub.respC <- gqlStatusErr(e)
 				// Remove our subscriber because we already responded.
-				delete(subscriptions, e.Path.String())
+				delete(batch.subscribers, e.Path.String())
 			}
 		} else if err != nil {
 			// For everything else return the status code to all our subscribers.
-			Log(ctx).Warn("batched query error", "count", qb.fields, "err", err, "resp.Errors", resp.Errors)
-			for _, sub := range subscriptions {
+			Log(ctx).Warn("batched query error", "count", len(batch.subscribers), "err", err, "resp.Errors", resp.Errors)
+			for _, sub := range batch.subscribers {
 				sub.respC <- gqlStatusErr(err)
 			}
 			return
 		}
 
-		for id, sub := range subscriptions {
+		for id, sub := range batch.subscribers {
 			// TODO: missing response.
 			byt, err := json.Marshal(map[string]any{
 				sub.field: data[id],
@@ -120,10 +124,7 @@ func (c *batchedgqlclient) flush(ctx context.Context) {
 
 			sub.respC <- json.Unmarshal(byt, &sub.resp.Data)
 		}
-	}(c.qb)
-
-	c.qb = newQueryBuilder()
-	c.subscriptions = map[string]*subscription{}
+	}(batch)
 }
 
 // MakeRequest implements graphql.Client.
@@ -146,6 +147,14 @@ func (c *batchedgqlclient) enqueue(
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	if len(c.queue) == 0 || len(c.queue[len(c.queue)-1].subscribers) >= c.batchSize {
+		c.queue = append(c.queue, batchedQuery{
+			qb:          newQueryBuilder(),
+			subscribers: map[string]*subscription{},
+		})
+	}
+	batch := c.queue[len(c.queue)-1]
+
 	respC := make(chan error, 1)
 
 	sub := &subscription{
@@ -158,12 +167,12 @@ func (c *batchedgqlclient) enqueue(
 	out, _ := json.Marshal(req.Variables)
 	_ = json.Unmarshal(out, &vars)
 
-	id, field, err := c.qb.add(req.Query, vars)
+	id, field, err := batch.qb.add(req.Query, vars)
 	if err != nil {
 		respC <- err
 	}
 
-	c.subscriptions[id] = &subscription{
+	batch.subscribers[id] = &subscription{
 		ctx:   ctx,
 		resp:  resp,
 		respC: respC,
@@ -201,9 +210,13 @@ func gqlStatusErr(err error) error {
 // queryBuilder accumulates queries into one query with multiple fields so they
 // can all be executed as part of one request.
 type queryBuilder struct {
-	op     *ast.OperationDefinition
-	fields int
-	vars   map[string]any
+	op   *ast.OperationDefinition
+	vars map[string]any
+}
+
+type batchedQuery struct {
+	qb          *queryBuilder
+	subscribers map[string]*subscription
 }
 
 // newQueryBuilder initializes a new QueryBuilder with an empty Document.
@@ -275,8 +288,6 @@ func (qb *queryBuilder) add(query string, vars map[string]any) (id string, field
 			},
 		})
 		visitor.Visit(opDef, opts, nil)
-
-		qb.fields++
 
 		if qb.op == opDef {
 			continue

--- a/internal/graphql.go
+++ b/internal/graphql.go
@@ -147,6 +147,7 @@ func (c *batchedgqlclient) enqueue(
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	// Take the youngest batch if it isn't full yet, otherwise start a new batch.
 	if len(c.queue) == 0 || len(c.queue[len(c.queue)-1].subscribers) >= c.batchSize {
 		c.queue = append(c.queue, batchedQuery{
 			qb:          newQueryBuilder(),

--- a/internal/handler.go
+++ b/internal/handler.go
@@ -304,7 +304,6 @@ func (h *Handler) getAuthorID(w http.ResponseWriter, r *http.Request) {
 		bytes, _ := h.ctrl.cache.Get(r.Context(), AuthorKey(authorID))
 		_ = h.ctrl.cache.Expire(r.Context(), AuthorKey(authorID))
 		go func() {
-			// TODO: Check if query param
 			if r.URL.Query().Get("full") != "" {
 				// Expire all works/editions.
 				var author AuthorResource

--- a/internal/handler.go
+++ b/internal/handler.go
@@ -286,6 +286,11 @@ func (h *Handler) getBookID(w http.ResponseWriter, r *http.Request) {
 //
 // If an ?edition={bookID} query param is present, as with a /book/{id}
 // redirect, an author is returned with only that work/edition.
+//
+// DELETE requests cause the author's record to be refreshed, which can be
+// helpful for example in cases where the author's works aren't in sorted
+// order. Include a `?full=true` query param in order to refresh all works and
+// editions belonging to the author as well.
 func (h *Handler) getAuthorID(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
@@ -299,15 +304,19 @@ func (h *Handler) getAuthorID(w http.ResponseWriter, r *http.Request) {
 		bytes, _ := h.ctrl.cache.Get(r.Context(), AuthorKey(authorID))
 		_ = h.ctrl.cache.Expire(r.Context(), AuthorKey(authorID))
 		go func() {
-			// Expire all works/editions and then kick off a refresh.
-			var author AuthorResource
-			_ = json.Unmarshal(bytes, &author)
-			for _, w := range author.Works {
-				for _, b := range w.Books {
-					_ = h.ctrl.cache.Expire(context.Background(), BookKey(b.ForeignID))
+			// TODO: Check if query param
+			if r.URL.Query().Get("full") != "" {
+				// Expire all works/editions.
+				var author AuthorResource
+				_ = json.Unmarshal(bytes, &author)
+				for _, w := range author.Works {
+					for _, b := range w.Books {
+						_ = h.ctrl.cache.Expire(context.Background(), BookKey(b.ForeignID))
+					}
+					_ = h.ctrl.cache.Expire(context.Background(), WorkKey(w.ForeignID))
 				}
-				_ = h.ctrl.cache.Expire(context.Background(), WorkKey(w.ForeignID))
 			}
+			// Kick off a refresh.
 			_, _ = h.ctrl.GetAuthor(context.Background(), authorID)
 		}()
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
We get a 403 response whenever our batched query includes more than 6 fields.

This changes the query batcher to now queue/execute things in batches of 6 or less.

Also add some logging to help see how backed up things are.