### PR TITLE
Small performance improvements

### DIFF
--- a/internal/gr.go
+++ b/internal/gr.go
@@ -147,7 +147,7 @@ func (g *GRGetter) GetWork(ctx context.Context, workID int64, loadEditions editi
 
 // GetBook fetches a book (edition) from GR.
 func (g *GRGetter) GetBook(ctx context.Context, bookID int64, loadEditions editionsCallback) (_ []byte, workID, authorID int64, _ error) {
-	if workBytes, ttl, ok := g.cache.GetWithTTL(ctx, BookKey(bookID)); ok && ttl > 0 && loadEditions == nil {
+	if workBytes, ttl, ok := g.cache.GetWithTTL(ctx, BookKey(bookID)); ok && ttl > 0 {
 		return workBytes, 0, 0, nil
 	}
 


### PR DESCRIPTION
* Short-circuit denormalization when it's for the unknown author, which never loads.
* Always respect the book's TTL. During work refresh we're causing books to be unnecessarily refreshed.
* Use a buffer pool when unmarshalling during denormalization.
* Use a buffer pool when zipping/unzipping DB rows.