### PR TITLE
Compute etags to short-circuit denormalization

### DIFF
--- a/internal/controller.go
+++ b/internal/controller.go
@@ -509,14 +509,14 @@ func (c *Controller) denormalizeEditions(ctx context.Context, workID int64, book
 
 	buf := _buffers.Get()
 	defer buf.Free()
-	new_ := newETagWriter()
-	w := io.MultiWriter(buf, new_)
+	neww := newETagWriter()
+	w := io.MultiWriter(buf, neww)
 	err = json.NewEncoder(w).Encode(work)
 	if err != nil {
 		return err
 	}
 
-	if new_.ETag() == old.ETag() {
+	if neww.ETag() == old.ETag() {
 		// The work didn't change, so we're done.
 		return nil
 	}
@@ -688,14 +688,14 @@ func (c *Controller) denormalizeWorks(ctx context.Context, authorID int64, workI
 
 	buf := _buffers.Get()
 	defer buf.Free()
-	new_ := newETagWriter()
-	w := io.MultiWriter(buf, new_)
+	neww := newETagWriter()
+	w := io.MultiWriter(buf, neww)
 	err = json.NewEncoder(w).Encode(author)
 	if err != nil {
 		return err
 	}
 
-	if new_.ETag() == old.ETag() {
+	if neww.ETag() == old.ETag() {
 		// The author didn't change, so we're done.
 		return nil
 	}

--- a/internal/controller.go
+++ b/internal/controller.go
@@ -509,14 +509,14 @@ func (c *Controller) denormalizeEditions(ctx context.Context, workID int64, book
 
 	buf := _buffers.Get()
 	defer buf.Free()
-	new := newETagWriter()
-	w := io.MultiWriter(buf, new)
+	new_ := newETagWriter()
+	w := io.MultiWriter(buf, new_)
 	err = json.NewEncoder(w).Encode(work)
 	if err != nil {
 		return err
 	}
 
-	if new.ETag() == old.ETag() {
+	if new_.ETag() == old.ETag() {
 		// The work didn't change, so we're done.
 		return nil
 	}
@@ -688,14 +688,14 @@ func (c *Controller) denormalizeWorks(ctx context.Context, authorID int64, workI
 
 	buf := _buffers.Get()
 	defer buf.Free()
-	new := newETagWriter()
-	w := io.MultiWriter(buf, new)
+	new_ := newETagWriter()
+	w := io.MultiWriter(buf, new_)
 	err = json.NewEncoder(w).Encode(author)
 	if err != nil {
 		return err
 	}
 
-	if new.ETag() == old.ETag() {
+	if new_.ETag() == old.ETag() {
 		// The author didn't change, so we're done.
 		return nil
 	}

--- a/internal/etag.go
+++ b/internal/etag.go
@@ -1,0 +1,21 @@
+package internal
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"hash"
+)
+
+// etagReader is an io.Writer that computes an MD5 etag for the contents
+// written to is.
+type etagger struct {
+	hash.Hash
+}
+
+func newETagWriter() *etagger {
+	return &etagger{Hash: md5.New()}
+}
+
+func (e *etagger) ETag() string {
+	return hex.EncodeToString(e.Sum(nil))
+}


### PR DESCRIPTION
I have a hunch we're trigger more denormalization than necessary when we upsert records that haven't changed.

This could also be wrong - it's possible we see things like ratings constantly change so often that records never match.