### PR TITLE
Ignore invalid large dates

### DIFF
--- a/internal/gr.go
+++ b/internal/gr.go
@@ -500,6 +500,10 @@ func releaseDate(t float64) string {
 		return ""
 	}
 
+	if ts.After(time.Date(9999, 12, 31, 23, 59, 59, 0, time.UTC)) {
+		return ""
+	}
+
 	return ts.Format(time.DateTime)
 }
 

--- a/internal/gr_test.go
+++ b/internal/gr_test.go
@@ -267,6 +267,11 @@ func TestReleaseDate(t *testing.T) {
 			want:  "",
 		},
 		{
+			// Similarly dates after 9999 are likely typos and should be ignored.
+			given: 253402329599999,
+			want:  "",
+		},
+		{
 			given: -62135596700000,
 			want:  "0001-01-01 00:01:40",
 		},


### PR DESCRIPTION
GR can have release date typos that exceed the range of C#'s DateTime.Parse, so ignore them.