### PR TITLE
Add Cloudflare cache busting

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ graph LR;
 > to me directly if you have questions or need help, please don't bother the R——
 > team.
 
-As of July 2025 there are ~3500 users of the shared instance. Here's what some
+As of July 2025 there are ~4500 users of the shared instance. Here's what some
 of them have said so far:
 
 > Man this is wayyyyyy better than the inhouse metadata, thank you!!

--- a/README.md
+++ b/README.md
@@ -277,7 +277,6 @@ welcome!
 
 ### TODO
 
-- [ ] (Prod) Add Cloudflare client for CDN invalidation.
 - [ ] (QOL) Ignore works/editions without publisher to cut down on
       self-published ebook slop.
 - [ ] (QOL) Update R—— client to send `Accept-Encoding: gzip` headers.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ graph LR;
 > to me directly if you have questions or need help, please don't bother the R——
 > team.
 
-As of June 2025 there are ~3000 users of the shared instance. Here's what some
+As of July 2025 there are ~3500 users of the shared instance. Here's what some
 of them have said so far:
 
 > Man this is wayyyyyy better than the inhouse metadata, thank you!!

--- a/cmd/rggr/main.go
+++ b/cmd/rggr/main.go
@@ -28,6 +28,7 @@ type cli struct {
 type server struct {
 	cmd.PGConfig
 	cmd.LogConfig
+	cmd.CloudflareConfig
 
 	Port       int    `default:"8788" env:"PORT" help:"Port to serve traffic on."`
 	RPM        int    `default:"60" env:"RPM" help:"Maximum upstream requests per minute."`
@@ -40,8 +41,13 @@ type server struct {
 func (s *server) Run() error {
 	_ = s.LogConfig.Run()
 
+	cf, err := s.CloudflareConfig.Cache()
+	if err != nil {
+		return fmt.Errorf("setting up cloudflare: %w", err)
+	}
+
 	ctx := context.Background()
-	cache, err := internal.NewCache(ctx, s.DSN())
+	cache, err := internal.NewCache(ctx, s.DSN(), cf)
 	if err != nil {
 		return fmt.Errorf("setting up cache: %w", err)
 	}

--- a/cmd/rghc/main.go
+++ b/cmd/rghc/main.go
@@ -28,6 +28,7 @@ type cli struct {
 type server struct {
 	cmd.PGConfig
 	cmd.LogConfig
+	cmd.CloudflareConfig
 
 	Port     int    `default:"8788" env:"PORT" help:"Port to serve traffic on."`
 	RPM      int    `default:"60" env:"RPM" help:"Maximum upstream requests per minute."`
@@ -42,8 +43,13 @@ type server struct {
 func (s *server) Run() error {
 	_ = s.LogConfig.Run()
 
+	cf, err := s.CloudflareConfig.Cache()
+	if err != nil {
+		return fmt.Errorf("setting up cloudflare: %w", err)
+	}
+
 	ctx := context.Background()
-	cache, err := internal.NewCache(ctx, s.DSN())
+	cache, err := internal.NewCache(ctx, s.DSN(), cf)
 	if err != nil {
 		return fmt.Errorf("setting up cache: %w", err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -82,7 +82,7 @@ func (c *CloudflareConfig) Cache() (*internal.CloudflareCache, error) {
 		if strings.HasPrefix(key, "w") {
 			return fmt.Sprintf("https://%s/work/%s", c.CloudflareDomain, key[1:])
 		}
-		if strings.HasPrefix(key, "a") {
+		if strings.HasPrefix(key, "a") || strings.HasPrefix(key, "ra") {
 			return fmt.Sprintf("https://%s/author/%s", c.CloudflareDomain, key[1:])
 		}
 		return "https://" + c.CloudflareDomain

--- a/internal/cache.go
+++ b/internal/cache.go
@@ -109,13 +109,17 @@ func (c *LayeredCache) Set(ctx context.Context, key string, val []byte, ttl time
 }
 
 // NewCache constructs a new layered cache.
-func NewCache(ctx context.Context, dsn string) (*LayeredCache, error) {
+func NewCache(ctx context.Context, dsn string, cf *CloudflareCache) (*LayeredCache, error) {
 	m := newMemoryCache()
 	pg, err := newPostgres(ctx, dsn)
 	if err != nil {
 		return nil, err
 	}
 	c := &LayeredCache{wrapped: []cache[[]byte]{m, pg}}
+
+	if cf != nil {
+		c.wrapped = append(c.wrapped, cf)
+	}
 
 	// Log cache stats every minute.
 	go func() {

--- a/internal/cloudflare.go
+++ b/internal/cloudflare.go
@@ -1,0 +1,177 @@
+package internal
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"net/http/httputil"
+	"sync"
+	"time"
+
+	"github.com/go-chi/chi/v5/middleware"
+	"golang.org/x/time/rate"
+)
+
+var _ cache[[]byte] = (*CloudflareCache)(nil)
+
+type cloudflareBuster struct {
+	mu sync.Mutex
+
+	url    string
+	client *http.Client
+	queue  map[string]struct{}
+}
+
+func newCloudflareBuster(apiToken string, zoneID string) (*cloudflareBuster, error) {
+	url := fmt.Sprintf("https://api.cloudflare.com/client/v4/zones/%s/purge_cache", zoneID)
+
+	client := &http.Client{
+		Transport: throttledTransport{
+			Limiter: rate.NewLimiter(rate.Limit(1), 1),
+			RoundTripper: ScopedTransport{
+				Host: "api.cloudflare.com",
+				RoundTripper: &HeaderTransport{
+					Key:          "Authorization",
+					Value:        "Bearer " + apiToken,
+					RoundTripper: http.DefaultTransport,
+				},
+			},
+		},
+	}
+	cb := &cloudflareBuster{
+		url:    url,
+		client: client,
+		queue:  map[string]struct{}{},
+	}
+	return cb, nil
+}
+
+func (cb *cloudflareBuster) Run(ctx context.Context) {
+	ticker := time.NewTicker(time.Second)
+	for {
+		select {
+		case <-ticker.C:
+			cb.flush(ctx)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (cb *cloudflareBuster) Add(url string) {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	cb.queue[url] = struct{}{}
+}
+
+func (cb *cloudflareBuster) flush(ctx context.Context) {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	if len(cb.queue) == 0 {
+		return
+	}
+
+	body := struct {
+		Files []string `json:"files"`
+	}{}
+
+	inflight := []string{}
+
+	for url := range maps.Keys(cb.queue) {
+		if len(body.Files) >= 800 {
+			break
+		}
+		body.Files = append(body.Files, url)
+		inflight = append(inflight, url)
+		delete(cb.queue, url)
+	}
+
+	Log(ctx).Debug("busting things", "count", len(body.Files))
+
+	r, w := io.Pipe()
+	defer w.Close()
+
+	go func() {
+		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		defer r.Close()
+
+		// If we don't succeed then re-add the failed URLs to our queue.
+		onError := func() {
+			cb.mu.Lock()
+			defer cb.mu.Unlock()
+			for _, url := range inflight {
+				cb.queue[url] = struct{}{}
+			}
+		}
+
+		req, err := http.NewRequestWithContext(ctx, "POST", cb.url, r)
+		if err != nil {
+			Log(ctx).Warn("problem requesting cloudflare", "err", err)
+			onError()
+			return
+		}
+		resp, err := cb.client.Do(req)
+		if err != nil {
+			Log(ctx).Warn("problem busting cloudflare", "err", err)
+			onError()
+			return
+		}
+		if resp.StatusCode != http.StatusOK {
+			dump, _ := httputil.DumpResponse(resp, true)
+			Log(ctx).Warn("unexpected cloudflare response", "dump", string(dump))
+			onError()
+			return
+		}
+	}()
+
+	err := json.NewEncoder(w).Encode(body)
+	if err != nil {
+		Log(ctx).Warn("problem serializing cloudflare", "err", err)
+	}
+}
+
+// CloudflareCache is a caching layer which no-ops except when new cache values
+// are written, in which case a cache bust is queued with Cloudflare.
+type CloudflareCache struct {
+	cb     *cloudflareBuster
+	pather func(string) string // Responsible for mapping cache keys to URLs for busting.
+}
+
+// NewCloudflareCache creates a new CloudflareCache.
+func NewCloudflareCache(apiKey string, zoneID string, pather func(string) string) (*CloudflareCache, error) {
+	cb, err := newCloudflareBuster(apiKey, zoneID)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := context.WithValue(context.Background(), middleware.RequestIDKey, "cloudflare")
+	go cb.Run(ctx)
+
+	return &CloudflareCache{cb: cb, pather: pather}, nil
+}
+
+// Expire busts the Cloudflare CDN by enqueuing the path to be busted.
+func (cc *CloudflareCache) Expire(ctx context.Context, key string) error {
+	cc.cb.Add(cc.pather(key))
+	return nil
+}
+
+// Set queues a URL for busting.
+func (cc *CloudflareCache) Set(ctx context.Context, key string, _ []byte, _ time.Duration) {
+	_ = cc.Expire(ctx, key)
+}
+
+// Get is a no-op.
+func (cc *CloudflareCache) Get(ctx context.Context, key string) ([]byte, bool) {
+	return nil, false
+}
+
+// GetWithTTL is a no-op.
+func (cc *CloudflareCache) GetWithTTL(ctx context.Context, key string) ([]byte, time.Duration, bool) {
+	return nil, 0, false
+}

--- a/internal/cloudflare.go
+++ b/internal/cloudflare.go
@@ -93,12 +93,12 @@ func (cb *cloudflareBuster) flush(ctx context.Context) {
 	Log(ctx).Debug("busting things", "count", len(body.Files))
 
 	r, w := io.Pipe()
-	defer w.Close()
+	defer func() { _ = w.Close() }()
 
 	go func() {
 		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
-		defer r.Close()
+		defer func() { _ = r.Close() }()
 
 		// If we don't succeed then re-add the failed URLs to our queue.
 		onError := func() {

--- a/internal/cloudflare.go
+++ b/internal/cloudflare.go
@@ -161,6 +161,12 @@ func (cc *CloudflareCache) Expire(ctx context.Context, key string) error {
 	return nil
 }
 
+// Delete is a no-op, since it's only used on our "refresh author" sentinel
+// which doesn't impact users.
+func (cc *CloudflareCache) Delete(ctx context.Context, key string) error {
+	return nil
+}
+
 // Set queues a URL for busting.
 func (cc *CloudflareCache) Set(ctx context.Context, key string, _ []byte, _ time.Duration) {
 	_ = cc.Expire(ctx, key)

--- a/internal/cloudflare.go
+++ b/internal/cloudflare.go
@@ -152,6 +152,17 @@ func NewCloudflareCache(apiKey string, zoneID string, pather func(string) string
 	ctx := context.WithValue(context.Background(), middleware.RequestIDKey, "cloudflare")
 	go cb.Run(ctx)
 
+	// Log cloudflare stats every minute.
+	go func() {
+		ctx := context.Background()
+		for {
+			time.Sleep(1 * time.Minute)
+			Log(ctx).Debug("cloudflare stats",
+				"queueSize", len(cb.queue),
+			)
+		}
+	}()
+
 	return &CloudflareCache{cb: cb, pather: pather}, nil
 }
 

--- a/internal/controller.go
+++ b/internal/controller.go
@@ -486,10 +486,10 @@ func (c *Controller) refreshAuthor(ctx context.Context, authorID int64, cachedBy
 // Run is responsible for denormalizing data. Race conditions are still
 // possible but less likely by serializing updates this way.
 func (c *Controller) Run(ctx context.Context, wait time.Duration) {
-	for edge := range groupEdges(c.denormC, wait) {
+	for edge := range groupEdges(ctx, c.denormC, wait) {
 		c.denormWaiting.Add(-int32(len(edge.childIDs)))
 
-		ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+		ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
 		ctx = context.WithValue(ctx, middleware.RequestIDKey, fmt.Sprintf("denorm-%d-%d", edge.kind, edge.parentID))
 
 		switch edge.kind {
@@ -513,7 +513,11 @@ func (c *Controller) Run(ctx context.Context, wait time.Duration) {
 // submitting their work and then closes the denormalization channel. Run will
 // run to completion after Shutdown is called.
 func (c *Controller) Shutdown(ctx context.Context) {
-	_ = c.refreshG.Wait()
+	// _ = c.refreshG.Wait()
+	//
+	//	for c.denormWaiting.Load() > 0 {
+	//		time.Sleep(1 * time.Second)
+	//	}
 }
 
 // denormalizeEditions ensures that the given editions exists on the work. It

--- a/internal/controller.go
+++ b/internal/controller.go
@@ -191,54 +191,58 @@ func NewController(cache cache[[]byte], getter getter, persister persister) (*Co
 
 // GetBook loads a book (edition) or returns a cached value if one exists.
 // TODO: This should only return a book!
-func (c *Controller) GetBook(ctx context.Context, bookID int64) ([]byte, error) {
-	out, err, _ := c.group.Do(BookKey(bookID), func() (any, error) {
+func (c *Controller) GetBook(ctx context.Context, bookID int64) ([]byte, time.Duration, error) {
+	p, err, _ := c.group.Do(BookKey(bookID), func() (any, error) {
 		return c.getBook(ctx, bookID)
 	})
-	return out.([]byte), err
+	pair := p.(ttlpair)
+	return pair.bytes, pair.ttl, err
 }
 
 // GetWork loads a work or returns a cached value if one exists.
-func (c *Controller) GetWork(ctx context.Context, workID int64) ([]byte, error) {
-	out, err, _ := c.group.Do(WorkKey(workID), func() (any, error) {
+func (c *Controller) GetWork(ctx context.Context, workID int64) ([]byte, time.Duration, error) {
+	p, err, _ := c.group.Do(WorkKey(workID), func() (any, error) {
 		return c.getWork(ctx, workID)
 	})
-	return out.([]byte), err
+	pair := p.(ttlpair)
+	return pair.bytes, pair.ttl, err
 }
 
 // GetAuthor loads an author or returns a cached value if one exists.
-func (c *Controller) GetAuthor(ctx context.Context, authorID int64) ([]byte, error) {
+func (c *Controller) GetAuthor(ctx context.Context, authorID int64) ([]byte, time.Duration, error) {
 	// The "unknown author" ID is never loadable, so we can short-circuit.
 	if unknownAuthor(authorID) {
-		return nil, errNotFound
+		return nil, _missingTTL, errNotFound
 	}
-	out, err, _ := c.group.Do(AuthorKey(authorID), func() (any, error) {
+	p, err, _ := c.group.Do(AuthorKey(authorID), func() (any, error) {
 		return c.getAuthor(ctx, authorID)
 	})
-	return out.([]byte), err
+	pair := p.(ttlpair)
+	return pair.bytes, pair.ttl, err
 }
 
-func (c *Controller) getBook(ctx context.Context, bookID int64) ([]byte, error) {
+func (c *Controller) getBook(ctx context.Context, bookID int64) (ttlpair, error) {
 	workBytes, ttl, ok := c.cache.GetWithTTL(ctx, BookKey(bookID))
 	if ok && ttl > 0 {
 		if slices.Equal(workBytes, _missing) {
-			return nil, errNotFound
+			return ttlpair{}, errNotFound
 		}
-		return workBytes, nil
+		return ttlpair{bytes: workBytes, ttl: ttl}, nil
 	}
 
 	// Cache miss.
 	workBytes, workID, authorID, err := c.getter.GetBook(ctx, bookID, c.saveEditions)
 	if errors.Is(err, errNotFound) {
 		c.cache.Set(ctx, BookKey(bookID), _missing, _missingTTL)
-		return nil, err
+		return ttlpair{}, err
 	}
 	if err != nil {
 		Log(ctx).Warn("problem getting book", "err", err, "bookID", bookID)
-		return nil, err
+		return ttlpair{}, err
 	}
 
-	c.cache.Set(ctx, BookKey(bookID), workBytes, fuzz(_editionTTL, 2.0))
+	ttl = fuzz(_editionTTL, 2.0)
+	c.cache.Set(ctx, BookKey(bookID), workBytes, ttl)
 
 	if workID > 0 {
 		// Ensure the edition/book is included with the work, but don't block the response.
@@ -250,30 +254,31 @@ func (c *Controller) getBook(ctx context.Context, bookID int64) ([]byte, error) 
 		}()
 	}
 
-	return workBytes, nil
+	return ttlpair{bytes: workBytes, ttl: ttl}, nil
 }
 
-func (c *Controller) getWork(ctx context.Context, workID int64) ([]byte, error) {
+func (c *Controller) getWork(ctx context.Context, workID int64) (ttlpair, error) {
 	cachedBytes, ttl, ok := c.cache.GetWithTTL(ctx, WorkKey(workID))
 	if ok && ttl > 0 {
 		if slices.Equal(cachedBytes, _missing) {
-			return nil, errNotFound
+			return ttlpair{}, errNotFound
 		}
-		return cachedBytes, nil
+		return ttlpair{bytes: cachedBytes, ttl: ttl}, nil
 	}
 
 	// Cache miss.
 	workBytes, authorID, err := c.getter.GetWork(ctx, workID, c.saveEditions)
 	if errors.Is(err, errNotFound) {
 		c.cache.Set(ctx, WorkKey(workID), _missing, _missingTTL)
-		return nil, err
+		return ttlpair{}, err
 	}
 	if err != nil {
 		Log(ctx).Warn("problem getting work", "err", err, "workID", workID)
-		return nil, err
+		return ttlpair{}, err
 	}
 
-	c.cache.Set(ctx, WorkKey(workID), workBytes, fuzz(_workTTL, 1.5))
+	ttl = fuzz(_workTTL, 1.5)
+	c.cache.Set(ctx, WorkKey(workID), workBytes, ttl)
 
 	// Ensuring relationships doesn't block.
 	go func() {
@@ -294,10 +299,10 @@ func (c *Controller) getWork(ctx context.Context, workID int64) ([]byte, error) 
 
 			cachedBookIDs := []int64{}
 			for _, b := range cached.Books {
-				_, _ = c.GetBook(ctx, b.ForeignID) // Ensure fetched.
+				_, _, _ = c.GetBook(ctx, b.ForeignID) // Ensure fetched.
 				cachedBookIDs = append(cachedBookIDs, b.ForeignID)
 			}
-			_, _ = c.GetAuthor(ctx, authorID) // Ensure fetched.
+			_, _, _ = c.GetAuthor(ctx, authorID) // Ensure fetched.
 
 			// Free up the refresh group for someone else.
 			go func() {
@@ -317,10 +322,10 @@ func (c *Controller) getWork(ctx context.Context, workID int64) ([]byte, error) 
 
 	// Return the last cached value to give the refresh time to complete.
 	if len(cachedBytes) > 0 {
-		return cachedBytes, err
+		return ttlpair{bytes: cachedBytes, ttl: ttl}, err
 	}
 
-	return workBytes, err
+	return ttlpair{bytes: workBytes, ttl: ttl}, err
 }
 
 func (c *Controller) saveEditions(grBooks ...workResource) {
@@ -345,7 +350,7 @@ func (c *Controller) saveEditions(grBooks ...workResource) {
 				continue
 			}
 			for _, a := range w.Authors {
-				_, _ = c.GetAuthor(ctx, a.ForeignID) // Ensure fetched.
+				_, _, _ = c.GetAuthor(ctx, a.ForeignID) // Ensure fetched.
 			}
 
 			book := w.Books[0]
@@ -369,7 +374,7 @@ func (c *Controller) saveEditions(grBooks ...workResource) {
 // getAuthor returns an AuthorResource with up to 20 works populated on first
 // load. Additional works are populated asynchronously. The previous state is
 // returned while a refresh is ongoing.
-func (c *Controller) getAuthor(ctx context.Context, authorID int64) ([]byte, error) {
+func (c *Controller) getAuthor(ctx context.Context, authorID int64) (ttlpair, error) {
 	// We prefer a refresh key, if one exists, because it contains the author's
 	// state prior to refreshing.
 	preRefreshBytes, ok := c.cache.Get(ctx, refreshAuthorKey(authorID))
@@ -385,22 +390,23 @@ func (c *Controller) getAuthor(ctx context.Context, authorID int64) ([]byte, err
 	cachedBytes, ttl, ok := c.cache.GetWithTTL(ctx, AuthorKey(authorID))
 	if ok && ttl > 0 {
 		if slices.Equal(cachedBytes, _missing) {
-			return nil, errNotFound
+			return ttlpair{}, errNotFound
 		}
-		return cachedBytes, nil
+		return ttlpair{bytes: cachedBytes, ttl: ttl}, nil
 	}
 
 	// Cache miss. Fetch new data.
 	authorBytes, err := c.getter.GetAuthor(ctx, authorID)
 	if errors.Is(err, errNotFound) {
 		c.cache.Set(ctx, AuthorKey(authorID), _missing, _missingTTL)
-		return nil, err
+		return ttlpair{}, err
 	}
 	if err != nil {
 		Log(ctx).Warn("problem getting author", "err", err, "authorID", authorID)
-		return nil, err
+		return ttlpair{}, err
 	}
-	c.cache.Set(ctx, AuthorKey(authorID), authorBytes, fuzz(_authorTTL, 1.5))
+	ttl := fuzz(_authorTTL, 1.5)
+	c.cache.Set(ctx, AuthorKey(authorID), authorBytes, ttl)
 
 	// From here we'll prefer to use the last-known state. If this is the first
 	// time we've loaded the author we won't have previous state, so use
@@ -418,7 +424,7 @@ func (c *Controller) getAuthor(ctx context.Context, authorID int64) ([]byte, err
 	go c.refreshAuthor(context.Background(), authorID, cachedBytes)
 
 	// Return the last cached value to give the refresh time to complete.
-	return cachedBytes, nil
+	return ttlpair{bytes: cachedBytes, ttl: ttl}, nil
 }
 
 func (c *Controller) refreshAuthor(ctx context.Context, authorID int64, cachedBytes []byte) {
@@ -641,9 +647,9 @@ func (c *Controller) denormalizeWorks(ctx context.Context, authorID int64, workI
 		return nil
 	}
 
-	authorBytes, err := c.GetAuthor(ctx, authorID)
+	authorBytes, _, err := c.GetAuthor(ctx, authorID)
 	if errors.Is(err, statusErr(http.StatusTooManyRequests)) {
-		authorBytes, err = c.GetAuthor(ctx, authorID) // Reload if we got a cold cache.
+		authorBytes, _, err = c.GetAuthor(ctx, authorID) // Reload if we got a cold cache.
 	}
 	if err != nil {
 		Log(ctx).Debug("problem loading author for denormalizeWorks", "err", err)
@@ -800,6 +806,11 @@ func fuzz(d time.Duration, f float64) time.Duration {
 	}
 	factor := 1.0 + rand.Float64()*(f-1.0)
 	return time.Duration(float64(d) * factor)
+}
+
+type ttlpair struct {
+	bytes []byte
+	ttl   time.Duration
 }
 
 // Configure sonic's memory pooling.

--- a/internal/controller_test.go
+++ b/internal/controller_test.go
@@ -97,7 +97,7 @@ func TestIncrementalDenormalization(t *testing.T) {
 	).AnyTimes()
 
 	// Getting the author will initially return it with only the "best" original-language edition.
-	authorBytes, err := ctrl.GetAuthor(ctx, author.ForeignID)
+	authorBytes, _, err := ctrl.GetAuthor(ctx, author.ForeignID)
 	require.NoError(t, err)
 
 	require.NoError(t, json.Unmarshal(authorBytes, &author))
@@ -106,19 +106,19 @@ func TestIncrementalDenormalization(t *testing.T) {
 	assert.Equal(t, englishEdition.ForeignID, author.Works[0].Books[0].ForeignID)
 
 	// Getting a foreign edition should add it to the work.
-	_, err = ctrl.GetBook(ctx, frenchEdition.ForeignID)
+	_, _, err = ctrl.GetBook(ctx, frenchEdition.ForeignID)
 	require.NoError(t, err)
 
 	waitForDenorm(ctrl)
 
-	workBytes, err := ctrl.GetWork(ctx, work.ForeignID)
+	workBytes, _, err := ctrl.GetWork(ctx, work.ForeignID)
 	require.NoError(t, err)
 	var w workResource
 	require.NoError(t, json.Unmarshal(workBytes, &w))
 	assert.Len(t, w.Books, 2)
 
 	// The work should have also been updated on the author.
-	authorBytes, err = ctrl.GetAuthor(ctx, author.ForeignID)
+	authorBytes, _, err = ctrl.GetAuthor(ctx, author.ForeignID)
 	require.NoError(t, err)
 	require.NoError(t, json.Unmarshal(authorBytes, &author))
 	assert.Len(t, author.Works, 1)
@@ -128,29 +128,29 @@ func TestIncrementalDenormalization(t *testing.T) {
 
 	// Force a cache miss to re-trigger denormalization.
 	_ = ctrl.cache.Expire(ctx, BookKey(frenchEdition.ForeignID))
-	_, _ = ctrl.GetBook(ctx, frenchEdition.ForeignID)
+	_, _, _ = ctrl.GetBook(ctx, frenchEdition.ForeignID)
 
 	_ = ctrl.refreshG.Wait()
 	time.Sleep(100 * time.Millisecond) // Wait for the denormalization goroutine update things.
 
-	workBytes, err = ctrl.GetWork(ctx, work.ForeignID)
+	workBytes, _, err = ctrl.GetWork(ctx, work.ForeignID)
 	require.NoError(t, err)
 	require.NoError(t, json.Unmarshal(workBytes, &w))
 	assert.Len(t, w.Books, 2)
 
-	authorBytes, err = ctrl.GetAuthor(ctx, author.ForeignID)
+	authorBytes, _, err = ctrl.GetAuthor(ctx, author.ForeignID)
 	require.NoError(t, err)
 	require.NoError(t, json.Unmarshal(authorBytes, &author))
 	assert.Len(t, author.Works[0].Books, 2)
 
 	// Force an author cache miss to re-trigger denormalization.
 	_ = ctrl.cache.Expire(ctx, AuthorKey(author.ForeignID))
-	_, _ = ctrl.GetAuthor(ctx, author.ForeignID)
+	_, _, _ = ctrl.GetAuthor(ctx, author.ForeignID)
 
 	_ = ctrl.refreshG.Wait()
 	time.Sleep(100 * time.Millisecond) // Wait for the denormalization goroutine update things.
 
-	authorBytes, err = ctrl.GetAuthor(ctx, author.ForeignID)
+	authorBytes, _, err = ctrl.GetAuthor(ctx, author.ForeignID)
 	require.NoError(t, err)
 	require.NoError(t, json.Unmarshal(authorBytes, &author))
 	assert.Len(t, author.Works[0].Books, 2)
@@ -361,7 +361,7 @@ func TestSubtitles(t *testing.T) {
 	err = ctrl.denormalizeWorks(ctx, author.ForeignID, workDupe4.ForeignID)
 	require.NoError(t, err)
 
-	authorBytes, err := ctrl.GetAuthor(ctx, author.ForeignID)
+	authorBytes, _, err := ctrl.GetAuthor(ctx, author.ForeignID)
 	require.NoError(t, err)
 
 	require.NoError(t, json.Unmarshal(authorBytes, &author))

--- a/internal/edges.go
+++ b/internal/edges.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"context"
 	"iter"
 	"time"
 )
@@ -24,7 +25,7 @@ type edge struct {
 //
 // If an edge isn't seen after the wait duration then we yield the last edge we
 // saw.
-func groupEdges(edges chan edge, wait time.Duration) iter.Seq[edge] {
+func groupEdges(ctx context.Context, edges chan edge, wait time.Duration) iter.Seq[edge] {
 	return func(yield func(edge) bool) {
 		var next edge
 		var ok bool
@@ -45,6 +46,8 @@ func groupEdges(edges chan edge, wait time.Duration) iter.Seq[edge] {
 				// Wait until we see the next edge, then start over.
 				edge = <-edges
 				continue
+			case <-ctx.Done():
+				return
 			}
 
 			// If the next edge is for the same parent and kind, then aggregate

--- a/internal/edges_test.go
+++ b/internal/edges_test.go
@@ -21,7 +21,7 @@ func TestGroupEdges(t *testing.T) {
 		close(c)
 	}()
 
-	edges := slices.Collect(groupEdges(c, time.Second))
+	edges := slices.Collect(groupEdges(t.Context(), c, time.Second))
 
 	assert.Equal(t, edges[0], edge{kind: authorEdge, parentID: 100, childIDs: []int64{1, 2, 3}})
 	assert.Equal(t, edges[1], edge{kind: workEdge, parentID: 100, childIDs: []int64{4}})

--- a/internal/gr_test.go
+++ b/internal/gr_test.go
@@ -271,8 +271,9 @@ func TestGRGetBookDataIntegrity(t *testing.T) {
 	t.Cleanup(func() { ctrl.Shutdown(t.Context()) })
 
 	t.Run("GetBook", func(t *testing.T) {
-		bookBytes, err := ctrl.GetBook(ctx, 6609765)
+		bookBytes, ttl, err := ctrl.GetBook(ctx, 6609765)
 		assert.NoError(t, err)
+		assert.NotZero(t, ttl)
 
 		var work workResource
 		require.NoError(t, json.Unmarshal(bookBytes, &work))
@@ -291,8 +292,9 @@ func TestGRGetBookDataIntegrity(t *testing.T) {
 	t.Run("GetAuthor", func(t *testing.T) {
 		waitForDenorm(ctrl)
 
-		authorBytes, err := ctrl.GetAuthor(ctx, 51942)
+		authorBytes, ttl, err := ctrl.GetAuthor(ctx, 51942)
 		require.NoError(t, err)
+		assert.NotZero(t, ttl)
 
 		// author -> .Works.Authors.Works must not be null, but books can be
 
@@ -310,13 +312,14 @@ func TestGRGetBookDataIntegrity(t *testing.T) {
 		require.NoError(t, ctrl.cache.Expire(t.Context(), WorkKey(6803732)))
 		require.NoError(t, ctrl.cache.Expire(t.Context(), BookKey(6609765)))
 
-		_, err := ctrl.GetWork(ctx, 6803732)
+		_, _, err := ctrl.GetWork(ctx, 6803732)
 		assert.NoError(t, err)
 
 		waitForDenorm(ctrl)
 
-		workBytes, err := ctrl.GetWork(ctx, 6803732)
+		workBytes, ttl, err := ctrl.GetWork(ctx, 6803732)
 		assert.NoError(t, err)
+		assert.NotZero(t, ttl)
 
 		var work workResource
 		require.NoError(t, json.Unmarshal(workBytes, &work))
@@ -449,8 +452,9 @@ func TestAuth(t *testing.T) {
 
 	t.Run("GetAuthor", func(t *testing.T) {
 		t.Parallel()
-		authorBytes, err := ctrl.GetAuthor(t.Context(), 4178)
+		authorBytes, ttl, err := ctrl.GetAuthor(t.Context(), 4178)
 		require.NoError(t, err)
+		assert.NotZero(t, ttl)
 
 		var author AuthorResource
 		err = json.Unmarshal(authorBytes, &author)
@@ -462,8 +466,9 @@ func TestAuth(t *testing.T) {
 
 	t.Run("GetBook", func(t *testing.T) {
 		t.Parallel()
-		bookBytes, err := ctrl.GetBook(t.Context(), 394535)
+		bookBytes, ttl, err := ctrl.GetBook(t.Context(), 394535)
 		assert.NoError(t, err)
+		assert.NotZero(t, ttl)
 
 		var work workResource
 		err = json.Unmarshal(bookBytes, &work)
@@ -474,8 +479,9 @@ func TestAuth(t *testing.T) {
 
 	t.Run("GetWork", func(t *testing.T) {
 		t.Parallel()
-		workBytes, err := ctrl.GetWork(t.Context(), 1930437)
+		workBytes, ttl, err := ctrl.GetWork(t.Context(), 1930437)
 		assert.NoError(t, err)
+		assert.NotZero(t, ttl)
 
 		var work workResource
 		err = json.Unmarshal(workBytes, &work)

--- a/internal/handler.go
+++ b/internal/handler.go
@@ -231,7 +231,7 @@ func (h *Handler) getWorkID(w http.ResponseWriter, r *http.Request) {
 //
 // Set varyParams to true if the cache key should include query params.
 func cacheFor(w http.ResponseWriter, d time.Duration, varyParams bool) {
-	w.Header().Add("Cache-Control", fmt.Sprintf("public, s-maxage=%d, max-age=3600", int(d.Seconds())))
+	w.Header().Add("Cache-Control", fmt.Sprintf("public, s-maxage=%d", int(d.Seconds())))
 	w.Header().Add("Vary", "Content-Type,Accept-Encoding") // Ignore headers like User-Agent, etc.
 	w.Header().Add("Content-Type", "application/json")
 	// w.Header().Add("Content-Encoding", "gzip") // TODO: Negotiate this with the client.

--- a/internal/handler.go
+++ b/internal/handler.go
@@ -136,7 +136,7 @@ func (h *Handler) bulkBook(w http.ResponseWriter, r *http.Request) {
 		go func(foreignBookID int64) {
 			defer wg.Done()
 
-			b, err := h.ctrl.GetBook(ctx, foreignBookID)
+			b, _, err := h.ctrl.GetBook(ctx, foreignBookID)
 			if err != nil {
 				if !errors.Is(err, errNotFound) {
 					Log(ctx).Warn("getting book", "err", err, "bookID", foreignBookID)
@@ -215,13 +215,15 @@ func (h *Handler) getWorkID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out, err := h.ctrl.GetWork(ctx, workID)
+	out, ttl, err := h.ctrl.GetWork(ctx, workID)
 	if err != nil {
 		h.error(w, err)
 		return
 	}
 
-	cacheFor(w, _workTTL, false)
+	if ttl > 0 {
+		cacheFor(w, ttl, false)
+	}
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(out)
 }
@@ -269,7 +271,7 @@ func (h *Handler) getBookID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	b, err := h.ctrl.GetBook(ctx, bookID)
+	b, ttl, err := h.ctrl.GetBook(ctx, bookID)
 	if err != nil {
 		h.error(w, err)
 		return
@@ -282,7 +284,9 @@ func (h *Handler) getBookID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cacheFor(w, _editionTTL, false)
+	if ttl > 0 {
+		cacheFor(w, ttl, false)
+	}
 
 	if len(workRsc.Authors) > 0 {
 		http.Redirect(w, r, fmt.Sprintf("/author/%d?edition=%d", workRsc.Authors[0].ForeignID, bookID), http.StatusSeeOther)
@@ -331,13 +335,13 @@ func (h *Handler) getAuthorID(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 			// Kick off a refresh.
-			_, _ = h.ctrl.GetAuthor(ctx, authorID)
+			_, _, _ = h.ctrl.GetAuthor(ctx, authorID)
 		}()
 		w.WriteHeader(http.StatusOK)
 		return
 	}
 
-	out, err := h.ctrl.GetAuthor(r.Context(), authorID)
+	out, ttl, err := h.ctrl.GetAuthor(r.Context(), authorID)
 	if err != nil {
 		h.error(w, err)
 		return
@@ -359,7 +363,7 @@ func (h *Handler) getAuthorID(w http.ResponseWriter, r *http.Request) {
 		}
 
 		var work workResource
-		ww, err := h.ctrl.GetBook(ctx, bookID)
+		ww, ttl, err := h.ctrl.GetBook(ctx, bookID)
 		if err != nil {
 			h.error(w, err)
 			return
@@ -373,13 +377,17 @@ func (h *Handler) getAuthorID(w http.ResponseWriter, r *http.Request) {
 
 		author.Works = []workResource{work}
 
-		cacheFor(w, _editionTTL, true)
+		if ttl > 0 {
+			cacheFor(w, ttl, true)
+		}
 		_ = json.NewEncoder(w).Encode(author)
 		return
 
 	}
 
-	cacheFor(w, _authorTTL, true)
+	if ttl > 0 {
+		cacheFor(w, ttl, true)
+	}
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(out)
 }

--- a/internal/hardcover_test.go
+++ b/internal/hardcover_test.go
@@ -236,8 +236,9 @@ func TestGetBookDataIntegrity(t *testing.T) {
 	t.Cleanup(func() { ctrl.Shutdown(t.Context()) })
 
 	t.Run("GetBook", func(t *testing.T) {
-		bookBytes, err := ctrl.GetBook(ctx, 6609765)
+		bookBytes, ttl, err := ctrl.GetBook(ctx, 6609765)
 		assert.NoError(t, err)
+		assert.NotZero(t, ttl)
 
 		var work workResource
 		require.NoError(t, json.Unmarshal(bookBytes, &work))
@@ -254,8 +255,9 @@ func TestGetBookDataIntegrity(t *testing.T) {
 	waitForDenorm(ctrl)
 
 	t.Run("GetAuthor", func(t *testing.T) {
-		authorBytes, err := ctrl.GetAuthor(ctx, 51942)
+		authorBytes, ttl, err := ctrl.GetAuthor(ctx, 51942)
 		assert.NoError(t, err)
+		assert.NotZero(t, ttl)
 
 		// author -> .Works.Authors.Works must not be null, but books can be
 
@@ -269,8 +271,9 @@ func TestGetBookDataIntegrity(t *testing.T) {
 	})
 
 	t.Run("GetWork", func(t *testing.T) {
-		workBytes, err := ctrl.GetWork(ctx, 6803732)
+		workBytes, ttl, err := ctrl.GetWork(ctx, 6803732)
 		assert.NoError(t, err)
+		assert.NotZero(t, ttl)
 
 		var work workResource
 		require.NoError(t, json.Unmarshal(workBytes, &work))

--- a/internal/persist_test.go
+++ b/internal/persist_test.go
@@ -11,7 +11,7 @@ func TestPersister(t *testing.T) {
 	ctx := t.Context()
 
 	dsn := "postgres://postgres@localhost:5432/test"
-	cache, err := NewCache(t.Context(), dsn)
+	cache, err := NewCache(t.Context(), dsn, nil)
 	require.NoError(t, err)
 
 	p, err := NewPersister(ctx, cache, dsn)

--- a/internal/postgres_test.go
+++ b/internal/postgres_test.go
@@ -53,7 +53,7 @@ func TestPostgresCache(t *testing.T) {
 
 	dsn := "postgres://postgres@localhost:5432/test"
 	ctx := context.Background()
-	cache, err := NewCache(ctx, dsn)
+	cache, err := NewCache(ctx, dsn, nil)
 	require.NoError(t, err)
 
 	n := 400
@@ -103,7 +103,7 @@ func TestPostgresCache(t *testing.T) {
 	t.Run("cold in-memory cache", func(t *testing.T) {
 		t.Parallel()
 		// Create a new cache.
-		coldCache, err := NewCache(ctx, dsn)
+		coldCache, err := NewCache(ctx, dsn, nil)
 		require.NoError(t, err)
 		checkCache(coldCache)
 	})


### PR DESCRIPTION
This adds a new (optional) Cloudflare caching layer. This layer is a no-op except on cache writes, when we queue a request to CF to bust the corresponding URL. My reading of the [API limits](https://developers.cloudflare.com/cache/how-to/purge-cache/#single-file-purge-limits) is we are allowed 800 URL busts per second, which should be more than enough.

I also updated the handler to return the current TTL instead of a fixed one, so CF will stay close to our own refresh schedule. This will allow me to turn on "cache everything" behavior while still keeping CF's cache fresh.

I noticed the shutdown logic was leaving zombies so I disabled that and can follow up in #90.