### PR TITLE
Load editions even more efficiently

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ graph LR;
 > to me directly if you have questions or need help, please don't bother the R——
 > team.
 
-As of June 2025 there are ~1400 users of the shared instance. Here's what some
+As of June 2025 there are ~3000 users of the shared instance. Here's what some
 of them have said so far:
 
 > Man this is wayyyyyy better than the inhouse metadata, thank you!!

--- a/cmd/rggr/main.go
+++ b/cmd/rggr/main.go
@@ -55,7 +55,14 @@ func (s *server) Run() error {
 		return err
 	}
 
-	gql, err := internal.NewGRGQL(ctx, upstream, s.Cookie)
+	// 3RPS seems to be the limit for all gql traffic, regardless of
+	// credentials. Batch size was confirmed empirically, although we still
+	// occasionally see failures for smaller batches for some reason.
+	// NB: 3RPS *should* be possible here, but I think there's a bad
+	// interaction between these requests and the upstream HEAD requests
+	// elsewhere. Especially if those result in a 404. That seems to trigger
+	// the WAF, which blocks everything for a period of time.
+	gql, err := internal.NewGRGQL(ctx, upstream, s.Cookie, time.Second/2.0, 6)
 	if err != nil {
 		return err
 	}

--- a/cmd/rggr/main.go
+++ b/cmd/rggr/main.go
@@ -109,10 +109,11 @@ func (s *server) Run() error {
 
 	go func() {
 		<-shutdown
-		slog.Info("waiting for denormalization to finish")
-		ctrl.Shutdown(ctx)
-		slog.Info("shutting down http server")
-		_ = server.Shutdown(ctx)
+		os.Exit(0)
+		//slog.Info("waiting for denormalization to finish")
+		//ctrl.Shutdown(ctx)
+		//slog.Info("shutting down http server")
+		//_ = server.Shutdown(ctx)
 	}()
 
 	ctrl.Run(ctx, 2*time.Second)

--- a/cmd/rghc/main.go
+++ b/cmd/rghc/main.go
@@ -115,10 +115,11 @@ func (s *server) Run() error {
 
 	go func() {
 		<-shutdown
-		slog.Info("shutting down http server")
-		_ = server.Shutdown(ctx)
-		slog.Info("waiting for denormalization to finish")
-		ctrl.Shutdown(ctx)
+		os.Exit(0)
+		//slog.Info("shutting down http server")
+		//_ = server.Shutdown(ctx)
+		//slog.Info("waiting for denormalization to finish")
+		//ctrl.Shutdown(ctx)
 	}()
 
 	ctrl.Run(ctx, 2*time.Second)

--- a/gr/generated.go
+++ b/gr/generated.go
@@ -4,9 +4,220 @@ package gr
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/Khan/genqlient/graphql"
 )
+
+// BookInfo includes the GraphQL fields of Book requested by the fragment BookInfo.
+type BookInfo struct {
+	Id                     string                                            `json:"id"`
+	LegacyId               int64                                             `json:"legacyId"`
+	Description            string                                            `json:"description"`
+	BookGenres             []BookInfoBookGenresBookGenre                     `json:"bookGenres"`
+	BookSeries             []BookInfoBookSeries                              `json:"bookSeries"`
+	Details                BookInfoDetailsBookDetails                        `json:"details"`
+	ImageUrl               string                                            `json:"imageUrl"`
+	PrimaryContributorEdge BookInfoPrimaryContributorEdgeBookContributorEdge `json:"primaryContributorEdge"`
+	Stats                  BookInfoStatsBookOrWorkStats                      `json:"stats"`
+	Title                  string                                            `json:"title"`
+	TitlePrimary           string                                            `json:"titlePrimary"`
+	WebUrl                 string                                            `json:"webUrl"`
+}
+
+// GetId returns BookInfo.Id, and is useful for accessing the field via an interface.
+func (v *BookInfo) GetId() string { return v.Id }
+
+// GetLegacyId returns BookInfo.LegacyId, and is useful for accessing the field via an interface.
+func (v *BookInfo) GetLegacyId() int64 { return v.LegacyId }
+
+// GetDescription returns BookInfo.Description, and is useful for accessing the field via an interface.
+func (v *BookInfo) GetDescription() string { return v.Description }
+
+// GetBookGenres returns BookInfo.BookGenres, and is useful for accessing the field via an interface.
+func (v *BookInfo) GetBookGenres() []BookInfoBookGenresBookGenre { return v.BookGenres }
+
+// GetBookSeries returns BookInfo.BookSeries, and is useful for accessing the field via an interface.
+func (v *BookInfo) GetBookSeries() []BookInfoBookSeries { return v.BookSeries }
+
+// GetDetails returns BookInfo.Details, and is useful for accessing the field via an interface.
+func (v *BookInfo) GetDetails() BookInfoDetailsBookDetails { return v.Details }
+
+// GetImageUrl returns BookInfo.ImageUrl, and is useful for accessing the field via an interface.
+func (v *BookInfo) GetImageUrl() string { return v.ImageUrl }
+
+// GetPrimaryContributorEdge returns BookInfo.PrimaryContributorEdge, and is useful for accessing the field via an interface.
+func (v *BookInfo) GetPrimaryContributorEdge() BookInfoPrimaryContributorEdgeBookContributorEdge {
+	return v.PrimaryContributorEdge
+}
+
+// GetStats returns BookInfo.Stats, and is useful for accessing the field via an interface.
+func (v *BookInfo) GetStats() BookInfoStatsBookOrWorkStats { return v.Stats }
+
+// GetTitle returns BookInfo.Title, and is useful for accessing the field via an interface.
+func (v *BookInfo) GetTitle() string { return v.Title }
+
+// GetTitlePrimary returns BookInfo.TitlePrimary, and is useful for accessing the field via an interface.
+func (v *BookInfo) GetTitlePrimary() string { return v.TitlePrimary }
+
+// GetWebUrl returns BookInfo.WebUrl, and is useful for accessing the field via an interface.
+func (v *BookInfo) GetWebUrl() string { return v.WebUrl }
+
+// BookInfoBookGenresBookGenre includes the requested fields of the GraphQL type BookGenre.
+type BookInfoBookGenresBookGenre struct {
+	Genre BookInfoBookGenresBookGenreGenre `json:"genre"`
+}
+
+// GetGenre returns BookInfoBookGenresBookGenre.Genre, and is useful for accessing the field via an interface.
+func (v *BookInfoBookGenresBookGenre) GetGenre() BookInfoBookGenresBookGenreGenre { return v.Genre }
+
+// BookInfoBookGenresBookGenreGenre includes the requested fields of the GraphQL type Genre.
+type BookInfoBookGenresBookGenreGenre struct {
+	Name string `json:"name"`
+}
+
+// GetName returns BookInfoBookGenresBookGenreGenre.Name, and is useful for accessing the field via an interface.
+func (v *BookInfoBookGenresBookGenreGenre) GetName() string { return v.Name }
+
+// BookInfoBookSeries includes the requested fields of the GraphQL type BookSeries.
+type BookInfoBookSeries struct {
+	Series          BookInfoBookSeriesSeries `json:"series"`
+	SeriesPlacement string                   `json:"seriesPlacement"`
+}
+
+// GetSeries returns BookInfoBookSeries.Series, and is useful for accessing the field via an interface.
+func (v *BookInfoBookSeries) GetSeries() BookInfoBookSeriesSeries { return v.Series }
+
+// GetSeriesPlacement returns BookInfoBookSeries.SeriesPlacement, and is useful for accessing the field via an interface.
+func (v *BookInfoBookSeries) GetSeriesPlacement() string { return v.SeriesPlacement }
+
+// BookInfoBookSeriesSeries includes the requested fields of the GraphQL type Series.
+type BookInfoBookSeriesSeries struct {
+	Id     string `json:"id"`
+	Title  string `json:"title"`
+	WebUrl string `json:"webUrl"`
+}
+
+// GetId returns BookInfoBookSeriesSeries.Id, and is useful for accessing the field via an interface.
+func (v *BookInfoBookSeriesSeries) GetId() string { return v.Id }
+
+// GetTitle returns BookInfoBookSeriesSeries.Title, and is useful for accessing the field via an interface.
+func (v *BookInfoBookSeriesSeries) GetTitle() string { return v.Title }
+
+// GetWebUrl returns BookInfoBookSeriesSeries.WebUrl, and is useful for accessing the field via an interface.
+func (v *BookInfoBookSeriesSeries) GetWebUrl() string { return v.WebUrl }
+
+// BookInfoDetailsBookDetails includes the requested fields of the GraphQL type BookDetails.
+type BookInfoDetailsBookDetails struct {
+	Asin            string                             `json:"asin"`
+	Isbn13          string                             `json:"isbn13"`
+	Format          string                             `json:"format"`
+	NumPages        int64                              `json:"numPages"`
+	Language        BookInfoDetailsBookDetailsLanguage `json:"language"`
+	OfficialUrl     string                             `json:"officialUrl"`
+	Publisher       string                             `json:"publisher"`
+	PublicationTime float64                            `json:"publicationTime"`
+}
+
+// GetAsin returns BookInfoDetailsBookDetails.Asin, and is useful for accessing the field via an interface.
+func (v *BookInfoDetailsBookDetails) GetAsin() string { return v.Asin }
+
+// GetIsbn13 returns BookInfoDetailsBookDetails.Isbn13, and is useful for accessing the field via an interface.
+func (v *BookInfoDetailsBookDetails) GetIsbn13() string { return v.Isbn13 }
+
+// GetFormat returns BookInfoDetailsBookDetails.Format, and is useful for accessing the field via an interface.
+func (v *BookInfoDetailsBookDetails) GetFormat() string { return v.Format }
+
+// GetNumPages returns BookInfoDetailsBookDetails.NumPages, and is useful for accessing the field via an interface.
+func (v *BookInfoDetailsBookDetails) GetNumPages() int64 { return v.NumPages }
+
+// GetLanguage returns BookInfoDetailsBookDetails.Language, and is useful for accessing the field via an interface.
+func (v *BookInfoDetailsBookDetails) GetLanguage() BookInfoDetailsBookDetailsLanguage {
+	return v.Language
+}
+
+// GetOfficialUrl returns BookInfoDetailsBookDetails.OfficialUrl, and is useful for accessing the field via an interface.
+func (v *BookInfoDetailsBookDetails) GetOfficialUrl() string { return v.OfficialUrl }
+
+// GetPublisher returns BookInfoDetailsBookDetails.Publisher, and is useful for accessing the field via an interface.
+func (v *BookInfoDetailsBookDetails) GetPublisher() string { return v.Publisher }
+
+// GetPublicationTime returns BookInfoDetailsBookDetails.PublicationTime, and is useful for accessing the field via an interface.
+func (v *BookInfoDetailsBookDetails) GetPublicationTime() float64 { return v.PublicationTime }
+
+// BookInfoDetailsBookDetailsLanguage includes the requested fields of the GraphQL type Language.
+type BookInfoDetailsBookDetailsLanguage struct {
+	Name string `json:"name"`
+}
+
+// GetName returns BookInfoDetailsBookDetailsLanguage.Name, and is useful for accessing the field via an interface.
+func (v *BookInfoDetailsBookDetailsLanguage) GetName() string { return v.Name }
+
+// BookInfoPrimaryContributorEdgeBookContributorEdge includes the requested fields of the GraphQL type BookContributorEdge.
+type BookInfoPrimaryContributorEdgeBookContributorEdge struct {
+	Node BookInfoPrimaryContributorEdgeBookContributorEdgeNodeContributor `json:"node"`
+}
+
+// GetNode returns BookInfoPrimaryContributorEdgeBookContributorEdge.Node, and is useful for accessing the field via an interface.
+func (v *BookInfoPrimaryContributorEdgeBookContributorEdge) GetNode() BookInfoPrimaryContributorEdgeBookContributorEdgeNodeContributor {
+	return v.Node
+}
+
+// BookInfoPrimaryContributorEdgeBookContributorEdgeNodeContributor includes the requested fields of the GraphQL type Contributor.
+type BookInfoPrimaryContributorEdgeBookContributorEdgeNodeContributor struct {
+	Id              string `json:"id"`
+	Name            string `json:"name"`
+	LegacyId        int64  `json:"legacyId"`
+	WebUrl          string `json:"webUrl"`
+	ProfileImageUrl string `json:"profileImageUrl"`
+	Description     string `json:"description"`
+}
+
+// GetId returns BookInfoPrimaryContributorEdgeBookContributorEdgeNodeContributor.Id, and is useful for accessing the field via an interface.
+func (v *BookInfoPrimaryContributorEdgeBookContributorEdgeNodeContributor) GetId() string {
+	return v.Id
+}
+
+// GetName returns BookInfoPrimaryContributorEdgeBookContributorEdgeNodeContributor.Name, and is useful for accessing the field via an interface.
+func (v *BookInfoPrimaryContributorEdgeBookContributorEdgeNodeContributor) GetName() string {
+	return v.Name
+}
+
+// GetLegacyId returns BookInfoPrimaryContributorEdgeBookContributorEdgeNodeContributor.LegacyId, and is useful for accessing the field via an interface.
+func (v *BookInfoPrimaryContributorEdgeBookContributorEdgeNodeContributor) GetLegacyId() int64 {
+	return v.LegacyId
+}
+
+// GetWebUrl returns BookInfoPrimaryContributorEdgeBookContributorEdgeNodeContributor.WebUrl, and is useful for accessing the field via an interface.
+func (v *BookInfoPrimaryContributorEdgeBookContributorEdgeNodeContributor) GetWebUrl() string {
+	return v.WebUrl
+}
+
+// GetProfileImageUrl returns BookInfoPrimaryContributorEdgeBookContributorEdgeNodeContributor.ProfileImageUrl, and is useful for accessing the field via an interface.
+func (v *BookInfoPrimaryContributorEdgeBookContributorEdgeNodeContributor) GetProfileImageUrl() string {
+	return v.ProfileImageUrl
+}
+
+// GetDescription returns BookInfoPrimaryContributorEdgeBookContributorEdgeNodeContributor.Description, and is useful for accessing the field via an interface.
+func (v *BookInfoPrimaryContributorEdgeBookContributorEdgeNodeContributor) GetDescription() string {
+	return v.Description
+}
+
+// BookInfoStatsBookOrWorkStats includes the requested fields of the GraphQL type BookOrWorkStats.
+type BookInfoStatsBookOrWorkStats struct {
+	AverageRating float64 `json:"averageRating"`
+	RatingsCount  int64   `json:"ratingsCount"`
+	RatingsSum    int64   `json:"ratingsSum"`
+}
+
+// GetAverageRating returns BookInfoStatsBookOrWorkStats.AverageRating, and is useful for accessing the field via an interface.
+func (v *BookInfoStatsBookOrWorkStats) GetAverageRating() float64 { return v.AverageRating }
+
+// GetRatingsCount returns BookInfoStatsBookOrWorkStats.RatingsCount, and is useful for accessing the field via an interface.
+func (v *BookInfoStatsBookOrWorkStats) GetRatingsCount() int64 { return v.RatingsCount }
+
+// GetRatingsSum returns BookInfoStatsBookOrWorkStats.RatingsSum, and is useful for accessing the field via an interface.
+func (v *BookInfoStatsBookOrWorkStats) GetRatingsSum() int64 { return v.RatingsSum }
 
 // GetAuthorWorksGetWorksByContributorContributorWorksConnection includes the requested fields of the GraphQL type ContributorWorksConnection.
 type GetAuthorWorksGetWorksByContributorContributorWorksConnection struct {
@@ -136,235 +347,138 @@ func (v *GetAuthorWorksResponse) GetGetWorksByContributor() GetAuthorWorksGetWor
 
 // GetBookGetBookByLegacyIdBook includes the requested fields of the GraphQL type Book.
 type GetBookGetBookByLegacyIdBook struct {
-	Id                     string                                                                `json:"id"`
-	LegacyId               int64                                                                 `json:"legacyId"`
-	Description            string                                                                `json:"description"`
-	BookGenres             []GetBookGetBookByLegacyIdBookBookGenresBookGenre                     `json:"bookGenres"`
-	BookSeries             []GetBookGetBookByLegacyIdBookBookSeries                              `json:"bookSeries"`
-	Details                GetBookGetBookByLegacyIdBookDetails                                   `json:"details"`
-	ImageUrl               string                                                                `json:"imageUrl"`
-	PrimaryContributorEdge GetBookGetBookByLegacyIdBookPrimaryContributorEdgeBookContributorEdge `json:"primaryContributorEdge"`
-	Stats                  GetBookGetBookByLegacyIdBookStatsBookOrWorkStats                      `json:"stats"`
-	Title                  string                                                                `json:"title"`
-	TitlePrimary           string                                                                `json:"titlePrimary"`
-	WebUrl                 string                                                                `json:"webUrl"`
-	Work                   GetBookGetBookByLegacyIdBookWork                                      `json:"work"`
+	BookInfo `json:"-"`
+	Work     GetBookGetBookByLegacyIdBookWork `json:"work"`
 }
-
-// GetId returns GetBookGetBookByLegacyIdBook.Id, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBook) GetId() string { return v.Id }
-
-// GetLegacyId returns GetBookGetBookByLegacyIdBook.LegacyId, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBook) GetLegacyId() int64 { return v.LegacyId }
-
-// GetDescription returns GetBookGetBookByLegacyIdBook.Description, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBook) GetDescription() string { return v.Description }
-
-// GetBookGenres returns GetBookGetBookByLegacyIdBook.BookGenres, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBook) GetBookGenres() []GetBookGetBookByLegacyIdBookBookGenresBookGenre {
-	return v.BookGenres
-}
-
-// GetBookSeries returns GetBookGetBookByLegacyIdBook.BookSeries, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBook) GetBookSeries() []GetBookGetBookByLegacyIdBookBookSeries {
-	return v.BookSeries
-}
-
-// GetDetails returns GetBookGetBookByLegacyIdBook.Details, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBook) GetDetails() GetBookGetBookByLegacyIdBookDetails {
-	return v.Details
-}
-
-// GetImageUrl returns GetBookGetBookByLegacyIdBook.ImageUrl, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBook) GetImageUrl() string { return v.ImageUrl }
-
-// GetPrimaryContributorEdge returns GetBookGetBookByLegacyIdBook.PrimaryContributorEdge, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBook) GetPrimaryContributorEdge() GetBookGetBookByLegacyIdBookPrimaryContributorEdgeBookContributorEdge {
-	return v.PrimaryContributorEdge
-}
-
-// GetStats returns GetBookGetBookByLegacyIdBook.Stats, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBook) GetStats() GetBookGetBookByLegacyIdBookStatsBookOrWorkStats {
-	return v.Stats
-}
-
-// GetTitle returns GetBookGetBookByLegacyIdBook.Title, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBook) GetTitle() string { return v.Title }
-
-// GetTitlePrimary returns GetBookGetBookByLegacyIdBook.TitlePrimary, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBook) GetTitlePrimary() string { return v.TitlePrimary }
-
-// GetWebUrl returns GetBookGetBookByLegacyIdBook.WebUrl, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBook) GetWebUrl() string { return v.WebUrl }
 
 // GetWork returns GetBookGetBookByLegacyIdBook.Work, and is useful for accessing the field via an interface.
 func (v *GetBookGetBookByLegacyIdBook) GetWork() GetBookGetBookByLegacyIdBookWork { return v.Work }
 
-// GetBookGetBookByLegacyIdBookBookGenresBookGenre includes the requested fields of the GraphQL type BookGenre.
-type GetBookGetBookByLegacyIdBookBookGenresBookGenre struct {
-	Genre GetBookGetBookByLegacyIdBookBookGenresBookGenreGenre `json:"genre"`
+// GetId returns GetBookGetBookByLegacyIdBook.Id, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBook) GetId() string { return v.BookInfo.Id }
+
+// GetLegacyId returns GetBookGetBookByLegacyIdBook.LegacyId, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBook) GetLegacyId() int64 { return v.BookInfo.LegacyId }
+
+// GetDescription returns GetBookGetBookByLegacyIdBook.Description, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBook) GetDescription() string { return v.BookInfo.Description }
+
+// GetBookGenres returns GetBookGetBookByLegacyIdBook.BookGenres, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBook) GetBookGenres() []BookInfoBookGenresBookGenre {
+	return v.BookInfo.BookGenres
 }
 
-// GetGenre returns GetBookGetBookByLegacyIdBookBookGenresBookGenre.Genre, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBookBookGenresBookGenre) GetGenre() GetBookGetBookByLegacyIdBookBookGenresBookGenreGenre {
-	return v.Genre
+// GetBookSeries returns GetBookGetBookByLegacyIdBook.BookSeries, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBook) GetBookSeries() []BookInfoBookSeries {
+	return v.BookInfo.BookSeries
 }
 
-// GetBookGetBookByLegacyIdBookBookGenresBookGenreGenre includes the requested fields of the GraphQL type Genre.
-type GetBookGetBookByLegacyIdBookBookGenresBookGenreGenre struct {
-	Name string `json:"name"`
+// GetDetails returns GetBookGetBookByLegacyIdBook.Details, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBook) GetDetails() BookInfoDetailsBookDetails {
+	return v.BookInfo.Details
 }
 
-// GetName returns GetBookGetBookByLegacyIdBookBookGenresBookGenreGenre.Name, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBookBookGenresBookGenreGenre) GetName() string { return v.Name }
+// GetImageUrl returns GetBookGetBookByLegacyIdBook.ImageUrl, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBook) GetImageUrl() string { return v.BookInfo.ImageUrl }
 
-// GetBookGetBookByLegacyIdBookBookSeries includes the requested fields of the GraphQL type BookSeries.
-type GetBookGetBookByLegacyIdBookBookSeries struct {
-	Series          GetBookGetBookByLegacyIdBookBookSeriesSeries `json:"series"`
-	SeriesPlacement string                                       `json:"seriesPlacement"`
+// GetPrimaryContributorEdge returns GetBookGetBookByLegacyIdBook.PrimaryContributorEdge, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBook) GetPrimaryContributorEdge() BookInfoPrimaryContributorEdgeBookContributorEdge {
+	return v.BookInfo.PrimaryContributorEdge
 }
 
-// GetSeries returns GetBookGetBookByLegacyIdBookBookSeries.Series, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBookBookSeries) GetSeries() GetBookGetBookByLegacyIdBookBookSeriesSeries {
-	return v.Series
+// GetStats returns GetBookGetBookByLegacyIdBook.Stats, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBook) GetStats() BookInfoStatsBookOrWorkStats {
+	return v.BookInfo.Stats
 }
 
-// GetSeriesPlacement returns GetBookGetBookByLegacyIdBookBookSeries.SeriesPlacement, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBookBookSeries) GetSeriesPlacement() string {
-	return v.SeriesPlacement
+// GetTitle returns GetBookGetBookByLegacyIdBook.Title, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBook) GetTitle() string { return v.BookInfo.Title }
+
+// GetTitlePrimary returns GetBookGetBookByLegacyIdBook.TitlePrimary, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBook) GetTitlePrimary() string { return v.BookInfo.TitlePrimary }
+
+// GetWebUrl returns GetBookGetBookByLegacyIdBook.WebUrl, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBook) GetWebUrl() string { return v.BookInfo.WebUrl }
+
+func (v *GetBookGetBookByLegacyIdBook) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*GetBookGetBookByLegacyIdBook
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.GetBookGetBookByLegacyIdBook = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.BookInfo)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
-// GetBookGetBookByLegacyIdBookBookSeriesSeries includes the requested fields of the GraphQL type Series.
-type GetBookGetBookByLegacyIdBookBookSeriesSeries struct {
-	Id     string `json:"id"`
-	Title  string `json:"title"`
+type __premarshalGetBookGetBookByLegacyIdBook struct {
+	Work GetBookGetBookByLegacyIdBookWork `json:"work"`
+
+	Id string `json:"id"`
+
+	LegacyId int64 `json:"legacyId"`
+
+	Description string `json:"description"`
+
+	BookGenres []BookInfoBookGenresBookGenre `json:"bookGenres"`
+
+	BookSeries []BookInfoBookSeries `json:"bookSeries"`
+
+	Details BookInfoDetailsBookDetails `json:"details"`
+
+	ImageUrl string `json:"imageUrl"`
+
+	PrimaryContributorEdge BookInfoPrimaryContributorEdgeBookContributorEdge `json:"primaryContributorEdge"`
+
+	Stats BookInfoStatsBookOrWorkStats `json:"stats"`
+
+	Title string `json:"title"`
+
+	TitlePrimary string `json:"titlePrimary"`
+
 	WebUrl string `json:"webUrl"`
 }
 
-// GetId returns GetBookGetBookByLegacyIdBookBookSeriesSeries.Id, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBookBookSeriesSeries) GetId() string { return v.Id }
-
-// GetTitle returns GetBookGetBookByLegacyIdBookBookSeriesSeries.Title, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBookBookSeriesSeries) GetTitle() string { return v.Title }
-
-// GetWebUrl returns GetBookGetBookByLegacyIdBookBookSeriesSeries.WebUrl, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBookBookSeriesSeries) GetWebUrl() string { return v.WebUrl }
-
-// GetBookGetBookByLegacyIdBookDetails includes the requested fields of the GraphQL type BookDetails.
-type GetBookGetBookByLegacyIdBookDetails struct {
-	Asin            string                                      `json:"asin"`
-	Isbn13          string                                      `json:"isbn13"`
-	Format          string                                      `json:"format"`
-	NumPages        int64                                       `json:"numPages"`
-	Language        GetBookGetBookByLegacyIdBookDetailsLanguage `json:"language"`
-	OfficialUrl     string                                      `json:"officialUrl"`
-	Publisher       string                                      `json:"publisher"`
-	PublicationTime float64                                     `json:"publicationTime"`
+func (v *GetBookGetBookByLegacyIdBook) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
 }
 
-// GetAsin returns GetBookGetBookByLegacyIdBookDetails.Asin, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBookDetails) GetAsin() string { return v.Asin }
+func (v *GetBookGetBookByLegacyIdBook) __premarshalJSON() (*__premarshalGetBookGetBookByLegacyIdBook, error) {
+	var retval __premarshalGetBookGetBookByLegacyIdBook
 
-// GetIsbn13 returns GetBookGetBookByLegacyIdBookDetails.Isbn13, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBookDetails) GetIsbn13() string { return v.Isbn13 }
-
-// GetFormat returns GetBookGetBookByLegacyIdBookDetails.Format, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBookDetails) GetFormat() string { return v.Format }
-
-// GetNumPages returns GetBookGetBookByLegacyIdBookDetails.NumPages, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBookDetails) GetNumPages() int64 { return v.NumPages }
-
-// GetLanguage returns GetBookGetBookByLegacyIdBookDetails.Language, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBookDetails) GetLanguage() GetBookGetBookByLegacyIdBookDetailsLanguage {
-	return v.Language
+	retval.Work = v.Work
+	retval.Id = v.BookInfo.Id
+	retval.LegacyId = v.BookInfo.LegacyId
+	retval.Description = v.BookInfo.Description
+	retval.BookGenres = v.BookInfo.BookGenres
+	retval.BookSeries = v.BookInfo.BookSeries
+	retval.Details = v.BookInfo.Details
+	retval.ImageUrl = v.BookInfo.ImageUrl
+	retval.PrimaryContributorEdge = v.BookInfo.PrimaryContributorEdge
+	retval.Stats = v.BookInfo.Stats
+	retval.Title = v.BookInfo.Title
+	retval.TitlePrimary = v.BookInfo.TitlePrimary
+	retval.WebUrl = v.BookInfo.WebUrl
+	return &retval, nil
 }
-
-// GetOfficialUrl returns GetBookGetBookByLegacyIdBookDetails.OfficialUrl, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBookDetails) GetOfficialUrl() string { return v.OfficialUrl }
-
-// GetPublisher returns GetBookGetBookByLegacyIdBookDetails.Publisher, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBookDetails) GetPublisher() string { return v.Publisher }
-
-// GetPublicationTime returns GetBookGetBookByLegacyIdBookDetails.PublicationTime, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBookDetails) GetPublicationTime() float64 { return v.PublicationTime }
-
-// GetBookGetBookByLegacyIdBookDetailsLanguage includes the requested fields of the GraphQL type Language.
-type GetBookGetBookByLegacyIdBookDetailsLanguage struct {
-	Name string `json:"name"`
-}
-
-// GetName returns GetBookGetBookByLegacyIdBookDetailsLanguage.Name, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBookDetailsLanguage) GetName() string { return v.Name }
-
-// GetBookGetBookByLegacyIdBookPrimaryContributorEdgeBookContributorEdge includes the requested fields of the GraphQL type BookContributorEdge.
-type GetBookGetBookByLegacyIdBookPrimaryContributorEdgeBookContributorEdge struct {
-	Node GetBookGetBookByLegacyIdBookPrimaryContributorEdgeBookContributorEdgeNodeContributor `json:"node"`
-}
-
-// GetNode returns GetBookGetBookByLegacyIdBookPrimaryContributorEdgeBookContributorEdge.Node, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBookPrimaryContributorEdgeBookContributorEdge) GetNode() GetBookGetBookByLegacyIdBookPrimaryContributorEdgeBookContributorEdgeNodeContributor {
-	return v.Node
-}
-
-// GetBookGetBookByLegacyIdBookPrimaryContributorEdgeBookContributorEdgeNodeContributor includes the requested fields of the GraphQL type Contributor.
-type GetBookGetBookByLegacyIdBookPrimaryContributorEdgeBookContributorEdgeNodeContributor struct {
-	Id              string `json:"id"`
-	Name            string `json:"name"`
-	LegacyId        int64  `json:"legacyId"`
-	WebUrl          string `json:"webUrl"`
-	ProfileImageUrl string `json:"profileImageUrl"`
-	Description     string `json:"description"`
-}
-
-// GetId returns GetBookGetBookByLegacyIdBookPrimaryContributorEdgeBookContributorEdgeNodeContributor.Id, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBookPrimaryContributorEdgeBookContributorEdgeNodeContributor) GetId() string {
-	return v.Id
-}
-
-// GetName returns GetBookGetBookByLegacyIdBookPrimaryContributorEdgeBookContributorEdgeNodeContributor.Name, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBookPrimaryContributorEdgeBookContributorEdgeNodeContributor) GetName() string {
-	return v.Name
-}
-
-// GetLegacyId returns GetBookGetBookByLegacyIdBookPrimaryContributorEdgeBookContributorEdgeNodeContributor.LegacyId, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBookPrimaryContributorEdgeBookContributorEdgeNodeContributor) GetLegacyId() int64 {
-	return v.LegacyId
-}
-
-// GetWebUrl returns GetBookGetBookByLegacyIdBookPrimaryContributorEdgeBookContributorEdgeNodeContributor.WebUrl, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBookPrimaryContributorEdgeBookContributorEdgeNodeContributor) GetWebUrl() string {
-	return v.WebUrl
-}
-
-// GetProfileImageUrl returns GetBookGetBookByLegacyIdBookPrimaryContributorEdgeBookContributorEdgeNodeContributor.ProfileImageUrl, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBookPrimaryContributorEdgeBookContributorEdgeNodeContributor) GetProfileImageUrl() string {
-	return v.ProfileImageUrl
-}
-
-// GetDescription returns GetBookGetBookByLegacyIdBookPrimaryContributorEdgeBookContributorEdgeNodeContributor.Description, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBookPrimaryContributorEdgeBookContributorEdgeNodeContributor) GetDescription() string {
-	return v.Description
-}
-
-// GetBookGetBookByLegacyIdBookStatsBookOrWorkStats includes the requested fields of the GraphQL type BookOrWorkStats.
-type GetBookGetBookByLegacyIdBookStatsBookOrWorkStats struct {
-	AverageRating float64 `json:"averageRating"`
-	RatingsCount  int64   `json:"ratingsCount"`
-	RatingsSum    int64   `json:"ratingsSum"`
-}
-
-// GetAverageRating returns GetBookGetBookByLegacyIdBookStatsBookOrWorkStats.AverageRating, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBookStatsBookOrWorkStats) GetAverageRating() float64 {
-	return v.AverageRating
-}
-
-// GetRatingsCount returns GetBookGetBookByLegacyIdBookStatsBookOrWorkStats.RatingsCount, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBookStatsBookOrWorkStats) GetRatingsCount() int64 {
-	return v.RatingsCount
-}
-
-// GetRatingsSum returns GetBookGetBookByLegacyIdBookStatsBookOrWorkStats.RatingsSum, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBookStatsBookOrWorkStats) GetRatingsSum() int64 { return v.RatingsSum }
 
 // GetBookGetBookByLegacyIdBookWork includes the requested fields of the GraphQL type Work.
 type GetBookGetBookByLegacyIdBookWork struct {
@@ -448,44 +562,144 @@ func (v *GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdge) 
 
 // GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook includes the requested fields of the GraphQL type Book.
 type GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook struct {
-	LegacyId int64                                                                                `json:"legacyId"`
-	Title    string                                                                               `json:"title"`
-	Details  GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetails `json:"details"`
+	BookInfo `json:"-"`
+}
+
+// GetId returns GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook.Id, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook) GetId() string {
+	return v.BookInfo.Id
 }
 
 // GetLegacyId returns GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook.LegacyId, and is useful for accessing the field via an interface.
 func (v *GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook) GetLegacyId() int64 {
-	return v.LegacyId
+	return v.BookInfo.LegacyId
+}
+
+// GetDescription returns GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook.Description, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook) GetDescription() string {
+	return v.BookInfo.Description
+}
+
+// GetBookGenres returns GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook.BookGenres, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook) GetBookGenres() []BookInfoBookGenresBookGenre {
+	return v.BookInfo.BookGenres
+}
+
+// GetBookSeries returns GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook.BookSeries, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook) GetBookSeries() []BookInfoBookSeries {
+	return v.BookInfo.BookSeries
+}
+
+// GetDetails returns GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook.Details, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook) GetDetails() BookInfoDetailsBookDetails {
+	return v.BookInfo.Details
+}
+
+// GetImageUrl returns GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook.ImageUrl, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook) GetImageUrl() string {
+	return v.BookInfo.ImageUrl
+}
+
+// GetPrimaryContributorEdge returns GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook.PrimaryContributorEdge, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook) GetPrimaryContributorEdge() BookInfoPrimaryContributorEdgeBookContributorEdge {
+	return v.BookInfo.PrimaryContributorEdge
+}
+
+// GetStats returns GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook.Stats, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook) GetStats() BookInfoStatsBookOrWorkStats {
+	return v.BookInfo.Stats
 }
 
 // GetTitle returns GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook.Title, and is useful for accessing the field via an interface.
 func (v *GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook) GetTitle() string {
-	return v.Title
+	return v.BookInfo.Title
 }
 
-// GetDetails returns GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook.Details, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook) GetDetails() GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetails {
-	return v.Details
+// GetTitlePrimary returns GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook.TitlePrimary, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook) GetTitlePrimary() string {
+	return v.BookInfo.TitlePrimary
 }
 
-// GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetails includes the requested fields of the GraphQL type BookDetails.
-type GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetails struct {
-	Language GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetailsLanguage `json:"language"`
+// GetWebUrl returns GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook.WebUrl, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook) GetWebUrl() string {
+	return v.BookInfo.WebUrl
 }
 
-// GetLanguage returns GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetails.Language, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetails) GetLanguage() GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetailsLanguage {
-	return v.Language
+func (v *GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.BookInfo)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
-// GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetailsLanguage includes the requested fields of the GraphQL type Language.
-type GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetailsLanguage struct {
-	Name string `json:"name"`
+type __premarshalGetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook struct {
+	Id string `json:"id"`
+
+	LegacyId int64 `json:"legacyId"`
+
+	Description string `json:"description"`
+
+	BookGenres []BookInfoBookGenresBookGenre `json:"bookGenres"`
+
+	BookSeries []BookInfoBookSeries `json:"bookSeries"`
+
+	Details BookInfoDetailsBookDetails `json:"details"`
+
+	ImageUrl string `json:"imageUrl"`
+
+	PrimaryContributorEdge BookInfoPrimaryContributorEdgeBookContributorEdge `json:"primaryContributorEdge"`
+
+	Stats BookInfoStatsBookOrWorkStats `json:"stats"`
+
+	Title string `json:"title"`
+
+	TitlePrimary string `json:"titlePrimary"`
+
+	WebUrl string `json:"webUrl"`
 }
 
-// GetName returns GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetailsLanguage.Name, and is useful for accessing the field via an interface.
-func (v *GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetailsLanguage) GetName() string {
-	return v.Name
+func (v *GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook) __premarshalJSON() (*__premarshalGetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook, error) {
+	var retval __premarshalGetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook
+
+	retval.Id = v.BookInfo.Id
+	retval.LegacyId = v.BookInfo.LegacyId
+	retval.Description = v.BookInfo.Description
+	retval.BookGenres = v.BookInfo.BookGenres
+	retval.BookSeries = v.BookInfo.BookSeries
+	retval.Details = v.BookInfo.Details
+	retval.ImageUrl = v.BookInfo.ImageUrl
+	retval.PrimaryContributorEdge = v.BookInfo.PrimaryContributorEdge
+	retval.Stats = v.BookInfo.Stats
+	retval.Title = v.BookInfo.Title
+	retval.TitlePrimary = v.BookInfo.TitlePrimary
+	retval.WebUrl = v.BookInfo.WebUrl
+	return &retval, nil
 }
 
 // GetBookResponse is returned by GetBook on success.
@@ -679,53 +893,7 @@ func GetAuthorWorks(
 const GetBook_Operation = `
 query GetBook ($legacyId: Int!) {
 	getBookByLegacyId(legacyId: $legacyId) {
-		id
-		legacyId
-		description(stripped: true)
-		bookGenres {
-			genre {
-				name
-			}
-		}
-		bookSeries {
-			series {
-				id
-				title
-				webUrl
-			}
-			seriesPlacement
-		}
-		details {
-			asin
-			isbn13
-			format
-			numPages
-			language {
-				name
-			}
-			officialUrl
-			publisher
-			publicationTime
-		}
-		imageUrl
-		primaryContributorEdge {
-			node {
-				id
-				name
-				legacyId
-				webUrl
-				profileImageUrl
-				description
-			}
-		}
-		stats {
-			averageRating
-			ratingsCount
-			ratingsSum
-		}
-		title
-		titlePrimary
-		webUrl
+		... BookInfo
 		work {
 			id
 			legacyId
@@ -741,18 +909,61 @@ query GetBook ($legacyId: Int!) {
 			editions {
 				edges {
 					node {
-						legacyId
-						title
-						details {
-							language {
-								name
-							}
-						}
+						... BookInfo
 					}
 				}
 			}
 		}
 	}
+}
+fragment BookInfo on Book {
+	id
+	legacyId
+	description(stripped: true)
+	bookGenres {
+		genre {
+			name
+		}
+	}
+	bookSeries {
+		series {
+			id
+			title
+			webUrl
+		}
+		seriesPlacement
+	}
+	details {
+		asin
+		isbn13
+		format
+		numPages
+		language {
+			name
+		}
+		officialUrl
+		publisher
+		publicationTime
+	}
+	imageUrl
+	primaryContributorEdge {
+		node {
+			id
+			name
+			legacyId
+			webUrl
+			profileImageUrl
+			description
+		}
+	}
+	stats {
+		averageRating
+		ratingsCount
+		ratingsSum
+	}
+	title
+	titlePrimary
+	webUrl
 }
 `
 

--- a/gr/queries.graphql
+++ b/gr/queries.graphql
@@ -1,52 +1,56 @@
+fragment BookInfo on Book {
+  id
+  legacyId
+  description(stripped: true)
+  bookGenres {
+    genre {
+      name
+    }
+  }
+  bookSeries {
+    series {
+      id
+      title
+      webUrl
+    }
+    seriesPlacement
+  }
+  details {
+    asin
+    isbn13
+    format
+    numPages
+    language {
+      name
+    }
+    officialUrl
+    publisher
+    publicationTime
+  }
+  imageUrl
+  primaryContributorEdge {
+    node {
+      id
+      name
+      legacyId
+      webUrl
+      profileImageUrl
+      description
+    }
+  }
+  stats {
+    averageRating
+    ratingsCount
+    ratingsSum
+  }
+  title
+  titlePrimary
+  webUrl
+}
+
 query GetBook($legacyId: Int!) {
   getBookByLegacyId(legacyId: $legacyId) {
-    id
-    legacyId
-    description(stripped: true)
-    bookGenres {
-      genre {
-        name
-      }
-    }
-    bookSeries {
-      series {
-        id
-        title
-        webUrl
-      }
-      seriesPlacement
-    }
-    details {
-      asin
-      isbn13
-      format
-      numPages
-      language {
-        name
-      }
-      officialUrl
-      publisher
-      publicationTime
-    }
-    imageUrl
-    primaryContributorEdge {
-      node {
-        id
-        name
-        legacyId
-        webUrl
-        profileImageUrl
-        description
-      }
-    }
-    stats {
-      averageRating
-      ratingsCount
-      ratingsSum
-    }
-    title
-    titlePrimary
-    webUrl
+    ...BookInfo
 
     work {
       id
@@ -63,13 +67,7 @@ query GetBook($legacyId: Int!) {
       editions {
         edges {
           node {
-            legacyId
-            title
-            details {
-              language {
-                name
-              }
-            }
+            ...BookInfo
           }
         }
       }

--- a/internal/controller.go
+++ b/internal/controller.go
@@ -302,7 +302,7 @@ func (c *Controller) getWork(ctx context.Context, workID int64) ([]byte, error) 
 
 func (c *Controller) saveEditions(grBooks ...workResource) {
 	go func() {
-		ctx := context.WithValue(context.Background(), middleware.RequestIDKey, fmt.Sprintf("load-editions-%d", time.Now().Unix()))
+		ctx := context.WithValue(context.Background(), middleware.RequestIDKey, fmt.Sprintf("save-editions-%d", time.Now().Unix()))
 
 		var grWorkID int64
 		grBookIDs := []int64{}

--- a/internal/controller.go
+++ b/internal/controller.go
@@ -82,8 +82,8 @@ type Controller struct {
 // getter allows alternative implementations of the core logic to be injected.
 // Don't write to the cache if you use it.
 type getter interface {
-	GetWork(ctx context.Context, workID int64, loadEditions editionsCallback) (_ []byte, authorID int64, _ error)
-	GetBook(ctx context.Context, bookID int64, loadEditions editionsCallback) (_ []byte, workID int64, authorID int64, _ error) // Returns a serialized Work??
+	GetWork(ctx context.Context, workID int64, saveEditions editionsCallback) (_ []byte, authorID int64, _ error)
+	GetBook(ctx context.Context, bookID int64, saveEditions editionsCallback) (_ []byte, workID int64, authorID int64, _ error) // Returns a serialized Work??
 	GetAuthor(ctx context.Context, authorID int64) ([]byte, error)
 	GetAuthorBooks(ctx context.Context, authorID int64) iter.Seq[int64] // Returns book/edition IDs, not works.
 }
@@ -207,7 +207,7 @@ func (c *Controller) getBook(ctx context.Context, bookID int64) ([]byte, error) 
 	}
 
 	// Cache miss.
-	workBytes, workID, _, err := c.getter.GetBook(ctx, bookID, c.loadEditions)
+	workBytes, workID, _, err := c.getter.GetBook(ctx, bookID, c.saveEditions)
 	if errors.Is(err, errNotFound) {
 		c.cache.Set(ctx, BookKey(bookID), _missing, _missingTTL)
 		return nil, err
@@ -240,7 +240,7 @@ func (c *Controller) getWork(ctx context.Context, workID int64) ([]byte, error) 
 	}
 
 	// Cache miss.
-	workBytes, authorID, err := c.getter.GetWork(ctx, workID, c.loadEditions)
+	workBytes, authorID, err := c.getter.GetWork(ctx, workID, c.saveEditions)
 	if errors.Is(err, errNotFound) {
 		c.cache.Set(ctx, WorkKey(workID), _missing, _missingTTL)
 		return nil, err
@@ -300,28 +300,43 @@ func (c *Controller) getWork(ctx context.Context, workID int64) ([]byte, error) 
 	return workBytes, err
 }
 
-func (c *Controller) loadEditions(grBookIDs ...int64) {
+func (c *Controller) saveEditions(grBooks ...workResource) {
 	go func() {
-		c.refreshWaiting.Add(1)
-		c.refreshG.Go(func() error {
-			ctx := context.WithValue(context.Background(), middleware.RequestIDKey, fmt.Sprintf("load-editions-%d", time.Now().Unix()))
+		ctx := context.WithValue(context.Background(), middleware.RequestIDKey, fmt.Sprintf("load-editions-%d", time.Now().Unix()))
 
-			defer func() {
-				c.refreshWaiting.Add(-1)
-				if r := recover(); r != nil {
-					Log(ctx).Error("panic", "details", r)
-				}
-			}()
+		var grWorkID int64
+		grBookIDs := []int64{}
 
-			for _, grBookID := range grBookIDs {
-				_, err := c.GetBook(ctx, grBookID)
-				if err != nil {
-					Log(ctx).Warn("problem loading edition", "grBookID", grBookID, "err", err)
-				}
+		for _, w := range grBooks {
+			if len(w.Books) != 1 {
+				// We expect a single book wrapped in a work -- side effect of R's odd data model.
+				Log(ctx).Warn("malformed edition", "grWorkID", w.ForeignID)
+				continue
+			}
+			if grWorkID == 0 {
+				grWorkID = w.ForeignID
+			}
+			if w.ForeignID != grWorkID {
+				// Editions should all belong to the same work.
+				Log(ctx).Warn("work-edition mismatch", "expected", grWorkID, "got", w.ForeignID)
+				continue
 			}
 
-			return nil
-		})
+			book := w.Books[0]
+			out, err := json.Marshal(w)
+			if err != nil {
+				continue
+			}
+			c.cache.Set(ctx, BookKey(book.ForeignID), out, fuzz(_editionTTL, 2.0))
+			grBookIDs = append(grBookIDs, book.ForeignID)
+		}
+
+		if grWorkID == 0 || len(grBookIDs) == 0 {
+			return // Shouldn't happen.
+		}
+
+		c.denormWaiting.Add(int32(len(grBookIDs)))
+		c.denormC <- edge{kind: workEdge, parentID: grWorkID, childIDs: grBookIDs}
 	}()
 }
 
@@ -726,7 +741,7 @@ func (c *Controller) denormalizeWorks(ctx context.Context, authorID int64, workI
 
 // editionsCallback can be used by a Getter to trigger async loading of
 // additional editions.
-type editionsCallback func(grBookIDs ...int64)
+type editionsCallback func(...workResource)
 
 func fuzz(d time.Duration, f float64) time.Duration {
 	if f > 1.0 {

--- a/internal/controller_test.go
+++ b/internal/controller_test.go
@@ -61,7 +61,7 @@ func TestIncrementalDenormalization(t *testing.T) {
 		return initialAuthorBytes, nil
 	}).AnyTimes()
 
-	getter.EXPECT().GetBook(gomock.Any(), englishEdition.ForeignID, gomock.Any()).DoAndReturn(func(ctx context.Context, bookID int64, loadEditions editionsCallback) ([]byte, int64, int64, error) {
+	getter.EXPECT().GetBook(gomock.Any(), englishEdition.ForeignID, gomock.Any()).DoAndReturn(func(ctx context.Context, bookID int64, saveEditions editionsCallback) ([]byte, int64, int64, error) {
 		cachedBytes, ok := ctrl.cache.Get(ctx, BookKey(bookID))
 		if ok {
 			return cachedBytes, 0, 0, nil
@@ -69,7 +69,7 @@ func TestIncrementalDenormalization(t *testing.T) {
 		return englishEditionBytes, work.ForeignID, authorID, nil
 	}).AnyTimes()
 
-	getter.EXPECT().GetBook(gomock.Any(), frenchEdition.ForeignID, gomock.Any()).DoAndReturn(func(ctx context.Context, bookID int64, loadEditions editionsCallback) ([]byte, int64, int64, error) {
+	getter.EXPECT().GetBook(gomock.Any(), frenchEdition.ForeignID, gomock.Any()).DoAndReturn(func(ctx context.Context, bookID int64, saveEditions editionsCallback) ([]byte, int64, int64, error) {
 		cachedBytes, ok := ctrl.cache.Get(ctx, BookKey(bookID))
 		if ok {
 			return cachedBytes, 0, 0, nil
@@ -77,7 +77,7 @@ func TestIncrementalDenormalization(t *testing.T) {
 		return frenchEditionBytes, work.ForeignID, authorID, nil
 	}).AnyTimes()
 
-	getter.EXPECT().GetWork(gomock.Any(), work.ForeignID, gomock.Any()).DoAndReturn(func(ctx context.Context, workID int64, loadEditions editionsCallback) ([]byte, int64, error) {
+	getter.EXPECT().GetWork(gomock.Any(), work.ForeignID, gomock.Any()).DoAndReturn(func(ctx context.Context, workID int64, saveEditions editionsCallback) ([]byte, int64, error) {
 		cachedBytes, ok := ctrl.cache.Get(ctx, WorkKey(workID))
 		if ok {
 			return cachedBytes, 0, nil
@@ -298,7 +298,7 @@ func TestSubtitles(t *testing.T) {
 		return initialAuthorBytes, nil
 	}).AnyTimes()
 
-	getter.EXPECT().GetWork(gomock.Any(), workDupe1.ForeignID, nil).DoAndReturn(func(ctx context.Context, workID int64, loadEditions editionsCallback) ([]byte, int64, error) {
+	getter.EXPECT().GetWork(gomock.Any(), workDupe1.ForeignID, nil).DoAndReturn(func(ctx context.Context, workID int64, saveEditions editionsCallback) ([]byte, int64, error) {
 		cachedBytes, ok := ctrl.cache.Get(ctx, WorkKey(workID))
 		if ok {
 			return cachedBytes, 0, nil
@@ -306,7 +306,7 @@ func TestSubtitles(t *testing.T) {
 		return initialWorkDupe1Bytes, author.ForeignID, nil
 	}).AnyTimes()
 
-	getter.EXPECT().GetWork(gomock.Any(), workDupe2.ForeignID, nil).DoAndReturn(func(ctx context.Context, workID int64, loadEditions editionsCallback) ([]byte, int64, error) {
+	getter.EXPECT().GetWork(gomock.Any(), workDupe2.ForeignID, nil).DoAndReturn(func(ctx context.Context, workID int64, saveEditions editionsCallback) ([]byte, int64, error) {
 		cachedBytes, ok := ctrl.cache.Get(ctx, WorkKey(workID))
 		if ok {
 			return cachedBytes, 0, nil
@@ -314,7 +314,7 @@ func TestSubtitles(t *testing.T) {
 		return initialWorkDupe2Bytes, author.ForeignID, nil
 	}).AnyTimes()
 
-	getter.EXPECT().GetWork(gomock.Any(), workDupe3.ForeignID, nil).DoAndReturn(func(ctx context.Context, workID int64, loadEditions editionsCallback) ([]byte, int64, error) {
+	getter.EXPECT().GetWork(gomock.Any(), workDupe3.ForeignID, nil).DoAndReturn(func(ctx context.Context, workID int64, saveEditions editionsCallback) ([]byte, int64, error) {
 		cachedBytes, ok := ctrl.cache.Get(ctx, WorkKey(workID))
 		if ok {
 			return cachedBytes, 0, nil
@@ -322,7 +322,7 @@ func TestSubtitles(t *testing.T) {
 		return initialWorkDupe3Bytes, author.ForeignID, nil
 	}).AnyTimes()
 
-	getter.EXPECT().GetWork(gomock.Any(), workDupe4.ForeignID, nil).DoAndReturn(func(ctx context.Context, workID int64, loadEditions editionsCallback) ([]byte, int64, error) {
+	getter.EXPECT().GetWork(gomock.Any(), workDupe4.ForeignID, nil).DoAndReturn(func(ctx context.Context, workID int64, saveEditions editionsCallback) ([]byte, int64, error) {
 		cachedBytes, ok := ctrl.cache.Get(ctx, WorkKey(workID))
 		if ok {
 			return cachedBytes, 0, nil
@@ -330,7 +330,7 @@ func TestSubtitles(t *testing.T) {
 		return initialWorkDupe4Bytes, author.ForeignID, nil
 	}).AnyTimes()
 
-	getter.EXPECT().GetWork(gomock.Any(), workUnique.ForeignID, nil).DoAndReturn(func(ctx context.Context, workID int64, loadEditions editionsCallback) ([]byte, int64, error) {
+	getter.EXPECT().GetWork(gomock.Any(), workUnique.ForeignID, nil).DoAndReturn(func(ctx context.Context, workID int64, saveEditions editionsCallback) ([]byte, int64, error) {
 		cachedBytes, ok := ctrl.cache.Get(ctx, WorkKey(workID))
 		if ok {
 			return cachedBytes, 0, nil
@@ -338,7 +338,7 @@ func TestSubtitles(t *testing.T) {
 		return initialWorkUniqueBytes, author.ForeignID, nil
 	}).AnyTimes()
 
-	getter.EXPECT().GetWork(gomock.Any(), workSeries.ForeignID, nil).DoAndReturn(func(ctx context.Context, workID int64, loadEditions editionsCallback) ([]byte, int64, error) {
+	getter.EXPECT().GetWork(gomock.Any(), workSeries.ForeignID, nil).DoAndReturn(func(ctx context.Context, workID int64, saveEditions editionsCallback) ([]byte, int64, error) {
 		cachedBytes, ok := ctrl.cache.Get(ctx, WorkKey(workID))
 		if ok {
 			return cachedBytes, 0, nil
@@ -410,7 +410,7 @@ func TestSortedInvariant(t *testing.T) {
 			},
 		}
 
-		getter.EXPECT().GetWork(gomock.Any(), gomock.Any(), nil).DoAndReturn(func(ctx context.Context, id int64, loadEditions editionsCallback) ([]byte, int64, error) {
+		getter.EXPECT().GetWork(gomock.Any(), gomock.Any(), nil).DoAndReturn(func(ctx context.Context, id int64, saveEditions editionsCallback) ([]byte, int64, error) {
 			bytes, err := json.Marshal(workResource{ForeignID: id, Books: []bookResource{{}}})
 			return bytes, 0, err
 		}).AnyTimes()
@@ -451,12 +451,12 @@ func TestSortedInvariant(t *testing.T) {
 			},
 		}
 
-		getter.EXPECT().GetWork(gomock.Any(), work.ForeignID, nil).DoAndReturn(func(ctx context.Context, id int64, loadEditions editionsCallback) ([]byte, int64, error) {
+		getter.EXPECT().GetWork(gomock.Any(), work.ForeignID, nil).DoAndReturn(func(ctx context.Context, id int64, saveEditions editionsCallback) ([]byte, int64, error) {
 			workBytes, err := json.Marshal(work)
 			return workBytes, 0, err
 		})
 
-		getter.EXPECT().GetBook(gomock.Any(), gomock.Any(), nil).DoAndReturn(func(ctx context.Context, id int64, loadEditions editionsCallback) ([]byte, int64, int64, error) {
+		getter.EXPECT().GetBook(gomock.Any(), gomock.Any(), nil).DoAndReturn(func(ctx context.Context, id int64, saveEditions editionsCallback) ([]byte, int64, int64, error) {
 			bytes, err := json.Marshal(workResource{ForeignID: work.ForeignID, Books: []bookResource{{ForeignID: id}}})
 			return bytes, 0, 0, err
 		}).AnyTimes()

--- a/internal/gr.go
+++ b/internal/gr.go
@@ -190,6 +190,7 @@ func (g *GRGetter) GetBook(ctx context.Context, bookID int64, saveEditions editi
 	return out, workRsc.ForeignID, workRsc.Authors[0].ForeignID, nil
 }
 
+// mapToWorkResource maps a GR book (edition) to the WorkResource model expected by R.
 func mapToWorkResource(book gr.BookInfo, work gr.GetBookGetBookByLegacyIdBookWork) workResource {
 	genres := []string{}
 	for _, g := range book.BookGenres {

--- a/internal/gr.go
+++ b/internal/gr.go
@@ -322,7 +322,7 @@ func (g *GRGetter) GetAuthor(ctx context.Context, authorID int64) ([]byte, error
 
 	var err error
 	if authorKCA == "" {
-		Log(ctx).Debug("resolving author ID", "authorID", authorID)
+		Log(ctx).Debug("resolving author KCA", "authorID", authorID)
 		authorKCA, err = g.legacyAuthorIDtoKCA(ctx, authorID)
 		if err != nil {
 			return nil, err
@@ -330,7 +330,7 @@ func (g *GRGetter) GetAuthor(ctx context.Context, authorID int64) ([]byte, error
 	}
 
 	if authorKCA == "" {
-		Log(ctx).Warn("unable to resolve author UID", "hit", ok)
+		Log(ctx).Warn("unable to resolve author KCA", "hit", ok)
 		return nil, fmt.Errorf("unable to resolve author %d", authorID)
 	}
 

--- a/internal/gr_test.go
+++ b/internal/gr_test.go
@@ -334,7 +334,7 @@ func TestBatchError(t *testing.T) {
 	upstream, err := NewUpstream(host, "", "")
 	require.NoError(t, err)
 
-	gql, err := NewGRGQL(t.Context(), upstream, "")
+	gql, err := NewGRGQL(t.Context(), upstream, "", time.Second, 2)
 	require.NoError(t, err)
 
 	var err1, err2 error
@@ -385,7 +385,7 @@ func TestAuth(t *testing.T) {
 	upstream, err := NewUpstream(host, cookie, "")
 	require.NoError(t, err)
 
-	gql, err := NewGRGQL(t.Context(), upstream, cookie)
+	gql, err := NewGRGQL(t.Context(), upstream, cookie, time.Second, 6)
 	require.NoError(t, err)
 
 	getter, err := NewGRGetter(cache, gql, upstream)
@@ -397,20 +397,38 @@ func TestAuth(t *testing.T) {
 
 	t.Run("GetAuthor", func(t *testing.T) {
 		t.Parallel()
-		_, err := ctrl.GetAuthor(t.Context(), 4178)
+		authorBytes, err := ctrl.GetAuthor(t.Context(), 4178)
 		assert.NoError(t, err)
+
+		var author AuthorResource
+		err = json.Unmarshal(authorBytes, &author)
+		assert.NoError(t, err)
+
+		assert.Equal(t, int64(4178), author.ForeignID)
 	})
 
 	t.Run("GetBook", func(t *testing.T) {
 		t.Parallel()
-		_, err := ctrl.GetBook(t.Context(), 394535)
+		bookBytes, err := ctrl.GetBook(t.Context(), 394535)
 		assert.NoError(t, err)
+
+		var work workResource
+		err = json.Unmarshal(bookBytes, &work)
+		assert.NoError(t, err)
+
+		assert.Equal(t, int64(394535), work.Books[0].ForeignID)
 	})
 
 	t.Run("GetWork", func(t *testing.T) {
 		t.Parallel()
-		_, err := ctrl.GetWork(t.Context(), 1930437)
+		workBytes, err := ctrl.GetWork(t.Context(), 1930437)
 		assert.NoError(t, err)
+
+		var work workResource
+		err = json.Unmarshal(workBytes, &work)
+		assert.NoError(t, err)
+
+		assert.Equal(t, int64(1930437), work.ForeignID)
 	})
 
 	t.Run("GetAuthorBooks", func(t *testing.T) {

--- a/internal/gr_test.go
+++ b/internal/gr_test.go
@@ -68,6 +68,8 @@ func TestGRGetBookDataIntegrity(t *testing.T) {
 		gomock.AssignableToTypeOf(&graphql.Response{})).DoAndReturn(
 		func(ctx context.Context, req *graphql.Request, res *graphql.Response) error {
 			if req.OpName == "GetBook" {
+				// We shouldn't re-query for any other books except the one we
+				// originally fetched.
 				if id := req.Variables.(interface{ GetLegacyId() int64 }).GetLegacyId(); id != 6609765 {
 					panic(id)
 				}
@@ -76,53 +78,55 @@ func TestGRGetBookDataIntegrity(t *testing.T) {
 					panic(gbr)
 				}
 				gbr.GetBookByLegacyId = gr.GetBookGetBookByLegacyIdBook{
-					Id:          "kca://book/amzn1.gr.book.v1.WY3sni8ilbLc2WGHV0N3SQ",
-					LegacyId:    6609765,
-					Description: "Melody is not like most people. She cannot walk or talk, but she has a photographic memory; she can remember every detail of everything she has ever experienced. She is smarter than most of the adults who try to diagnose her and smarter than her classmates in her integrated classroom - the very same classmates who dismiss her as mentally challenged because she cannot tell them otherwise. But Melody refuses to be defined by cerebral palsy. And she's determined to let everyone know it - somehow.",
-					BookGenres: []gr.GetBookGetBookByLegacyIdBookBookGenresBookGenre{
-						{Genre: gr.GetBookGetBookByLegacyIdBookBookGenresBookGenreGenre{Name: "Young Adult"}},
-					},
-					BookSeries: []gr.GetBookGetBookByLegacyIdBookBookSeries{
-						{
-							SeriesPlacement: "1",
-							Series: gr.GetBookGetBookByLegacyIdBookBookSeriesSeries{
-								Id:     "kca://series/amzn1.gr.series.v3.owomqLJFO4sueLJt",
-								Title:  "Out of My Mind",
-								WebUrl: "https://www.gr.com/series/326523-out-of-my-mind",
+					BookInfo: gr.BookInfo{
+						Id:          "kca://book/amzn1.gr.book.v1.WY3sni8ilbLc2WGHV0N3SQ",
+						LegacyId:    6609765,
+						Description: "Melody is not like most people. She cannot walk or talk, but she has a photographic memory; she can remember every detail of everything she has ever experienced. She is smarter than most of the adults who try to diagnose her and smarter than her classmates in her integrated classroom - the very same classmates who dismiss her as mentally challenged because she cannot tell them otherwise. But Melody refuses to be defined by cerebral palsy. And she's determined to let everyone know it - somehow.",
+						BookGenres: []gr.BookInfoBookGenresBookGenre{
+							{Genre: gr.BookInfoBookGenresBookGenreGenre{Name: "Young Adult"}},
+						},
+						BookSeries: []gr.BookInfoBookSeries{
+							{
+								SeriesPlacement: "1",
+								Series: gr.BookInfoBookSeriesSeries{
+									Id:     "kca://series/amzn1.gr.series.v3.owomqLJFO4sueLJt",
+									Title:  "Out of My Mind",
+									WebUrl: "https://www.gr.com/series/326523-out-of-my-mind",
+								},
 							},
 						},
-					},
-					Details: gr.GetBookGetBookByLegacyIdBookDetails{
-						Asin:     "141697170X",
-						Isbn13:   "9781416971702",
-						Format:   "Hardcover",
-						NumPages: 295,
-						Language: gr.GetBookGetBookByLegacyIdBookDetailsLanguage{
-							Name: "English",
+						Details: gr.BookInfoDetailsBookDetails{
+							Asin:     "141697170X",
+							Isbn13:   "9781416971702",
+							Format:   "Hardcover",
+							NumPages: 295,
+							Language: gr.BookInfoDetailsBookDetailsLanguage{
+								Name: "English",
+							},
+							OfficialUrl:     "",
+							Publisher:       "Atheneum Books for Young Readers",
+							PublicationTime: 1268121600000,
 						},
-						OfficialUrl:     "",
-						Publisher:       "Atheneum Books for Young Readers",
-						PublicationTime: 1268121600000,
-					},
-					ImageUrl: "https://images-na.ssl-images-amazon.com/images/S/compressed.photo.gr.com/books/1347602096i/6609765.jpg",
-					PrimaryContributorEdge: gr.GetBookGetBookByLegacyIdBookPrimaryContributorEdgeBookContributorEdge{
-						Node: gr.GetBookGetBookByLegacyIdBookPrimaryContributorEdgeBookContributorEdgeNodeContributor{
-							Id:   "kca://author/amzn1.gr.author.v1.tnLKwFVJefdFsJ6d34fT6Q",
-							Name: "Sharon M. Draper",
+						ImageUrl: "https://images-na.ssl-images-amazon.com/images/S/compressed.photo.gr.com/books/1347602096i/6609765.jpg",
+						PrimaryContributorEdge: gr.BookInfoPrimaryContributorEdgeBookContributorEdge{
+							Node: gr.BookInfoPrimaryContributorEdgeBookContributorEdgeNodeContributor{
+								Id:   "kca://author/amzn1.gr.author.v1.tnLKwFVJefdFsJ6d34fT6Q",
+								Name: "Sharon M. Draper",
 
-							LegacyId:        51942,
-							WebUrl:          "https://www.gr.com/author/show/51942.Sharon_M_Draper",
-							ProfileImageUrl: "https://i.gr-assets.com/images/S/compressed.photo.gr.com/authors/1236906847i/51942._UX200_CR0,49,200,200_.jpg",
-							Description:     "<i>Sharon M. Draper</i> is a professional educator as well as an accomplished writer. She has been honored as the National Teacher of the Year, is a five-time winner of the Coretta Scott King Literary Award, and is a New York Times bestselling author. She lives in Cincinnati, Ohio.",
+								LegacyId:        51942,
+								WebUrl:          "https://www.gr.com/author/show/51942.Sharon_M_Draper",
+								ProfileImageUrl: "https://i.gr-assets.com/images/S/compressed.photo.gr.com/authors/1236906847i/51942._UX200_CR0,49,200,200_.jpg",
+								Description:     "<i>Sharon M. Draper</i> is a professional educator as well as an accomplished writer. She has been honored as the National Teacher of the Year, is a five-time winner of the Coretta Scott King Literary Award, and is a New York Times bestselling author. She lives in Cincinnati, Ohio.",
+							},
 						},
+						Stats: gr.BookInfoStatsBookOrWorkStats{
+							AverageRating: 4.35,
+							RatingsCount:  156543,
+							RatingsSum:    680605,
+						},
+						TitlePrimary: "Out of My Mind",
+						WebUrl:       "https://www.gr.com/book/show/6609765-out-of-my-mind",
 					},
-					Stats: gr.GetBookGetBookByLegacyIdBookStatsBookOrWorkStats{
-						AverageRating: 4.35,
-						RatingsCount:  156543,
-						RatingsSum:    680605,
-					},
-					TitlePrimary: "Out of My Mind",
-					WebUrl:       "https://www.gr.com/book/show/6609765-out-of-my-mind",
 					Work: gr.GetBookGetBookByLegacyIdBookWork{
 						Id:       "kca://work/amzn1.gr.work.v1.DaUnQI3cWL066Bo8_EL8-A",
 						LegacyId: 6803732,
@@ -137,22 +141,39 @@ func TestGRGetBookDataIntegrity(t *testing.T) {
 							Edges: []gr.GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdge{
 								{
 									Node: gr.GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook{
-										LegacyId: 6609765,
-										Title:    "Out of My Mind",
-										Details: gr.GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetails{
-											Language: gr.GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetailsLanguage{
-												Name: "english",
+										BookInfo: gr.BookInfo{
+											LegacyId: 6609765,
+											Title:    "Out of My Mind",
+											Details: gr.BookInfoDetailsBookDetails{
+												Language: gr.BookInfoDetailsBookDetailsLanguage{
+													Name: "English",
+												},
 											},
 										},
 									},
 								},
 								{
 									Node: gr.GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook{
-										LegacyId: dupeEditionID, // Should be ignored since this is a dupe.
-										Title:    "OUT OF MY MIND",
-										Details: gr.GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetails{
-											Language: gr.GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBookDetailsLanguage{
-												Name: "english",
+										BookInfo: gr.BookInfo{
+											LegacyId: dupeEditionID, // Should be ignored since this is a dupe.
+											Title:    "OUT OF MY MIND",
+											Details: gr.BookInfoDetailsBookDetails{
+												Language: gr.BookInfoDetailsBookDetailsLanguage{
+													Name: "English",
+												},
+											},
+										},
+									},
+								},
+								{
+									Node: gr.GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook{
+										BookInfo: gr.BookInfo{
+											LegacyId: 6609766, // Should be included since it's a different language.
+											Title:    "Some other edition",
+											Details: gr.BookInfoDetailsBookDetails{
+												Language: gr.BookInfoDetailsBookDetailsLanguage{
+													Name: "German",
+												},
 											},
 										},
 									},
@@ -190,7 +211,7 @@ func TestGRGetBookDataIntegrity(t *testing.T) {
 			return nil
 		}).AnyTimes()
 
-	cache := &LayeredCache{wrapped: []cache[[]byte]{newMemoryCache()}}
+	cache := newMemoryCache()
 	getter, err := NewGRGetter(cache, gql, &http.Client{Transport: upstream})
 	require.NoError(t, err)
 
@@ -214,6 +235,8 @@ func TestGRGetBookDataIntegrity(t *testing.T) {
 
 		require.Len(t, work.Books, 1)
 		assert.Equal(t, int64(6609765), work.Books[0].ForeignID)
+
+		assert.Equal(t, "eng", work.Books[0].Language)
 	})
 
 	t.Run("GetAuthor", func(t *testing.T) {
@@ -236,6 +259,11 @@ func TestGRGetBookDataIntegrity(t *testing.T) {
 		require.NoError(t, ctrl.cache.Expire(t.Context(), WorkKey(6803732)))
 		require.NoError(t, ctrl.cache.Expire(t.Context(), BookKey(6609765)))
 
+		_, err := ctrl.GetWork(ctx, 6803732)
+		assert.NoError(t, err)
+
+		time.Sleep(10 * time.Millisecond)
+
 		workBytes, err := ctrl.GetWork(ctx, 6803732)
 		assert.NoError(t, err)
 
@@ -246,8 +274,9 @@ func TestGRGetBookDataIntegrity(t *testing.T) {
 		assert.Equal(t, int64(51942), work.Authors[0].ForeignID)
 		require.Len(t, work.Authors[0].Works, 1)
 
-		require.Len(t, work.Books, 1)
+		require.Len(t, work.Books, 2)
 		assert.Equal(t, int64(6609765), work.Books[0].ForeignID)
+		assert.Equal(t, int64(6609766), work.Books[1].ForeignID)
 	})
 }
 
@@ -351,7 +380,7 @@ func TestAuth(t *testing.T) {
 		return
 	}
 
-	cache := &LayeredCache{wrapped: []cache[[]byte]{newMemoryCache()}}
+	cache := newMemoryCache()
 
 	upstream, err := NewUpstream(host, cookie, "")
 	require.NoError(t, err)

--- a/internal/main_test.go
+++ b/internal/main_test.go
@@ -1,0 +1,14 @@
+package internal
+
+import (
+	"os"
+	"testing"
+
+	charm "github.com/charmbracelet/log"
+)
+
+func TestMain(m *testing.M) {
+	SetLogLevel(charm.DebugLevel)
+
+	os.Exit(m.Run())
+}

--- a/internal/mock.go
+++ b/internal/mock.go
@@ -119,9 +119,9 @@ func (c *MockgetterGetAuthorBooksCall) DoAndReturn(f func(context.Context, int64
 }
 
 // GetBook mocks base method.
-func (m *Mockgetter) GetBook(ctx context.Context, bookID int64, loadEditions editionsCallback) ([]byte, int64, int64, error) {
+func (m *Mockgetter) GetBook(ctx context.Context, bookID int64, saveEditions editionsCallback) ([]byte, int64, int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBook", ctx, bookID, loadEditions)
+	ret := m.ctrl.Call(m, "GetBook", ctx, bookID, saveEditions)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(int64)
 	ret2, _ := ret[2].(int64)
@@ -130,9 +130,9 @@ func (m *Mockgetter) GetBook(ctx context.Context, bookID int64, loadEditions edi
 }
 
 // GetBook indicates an expected call of GetBook.
-func (mr *MockgetterMockRecorder) GetBook(ctx, bookID, loadEditions any) *MockgetterGetBookCall {
+func (mr *MockgetterMockRecorder) GetBook(ctx, bookID, saveEditions any) *MockgetterGetBookCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBook", reflect.TypeOf((*Mockgetter)(nil).GetBook), ctx, bookID, loadEditions)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBook", reflect.TypeOf((*Mockgetter)(nil).GetBook), ctx, bookID, saveEditions)
 	return &MockgetterGetBookCall{Call: call}
 }
 
@@ -160,9 +160,9 @@ func (c *MockgetterGetBookCall) DoAndReturn(f func(context.Context, int64, editi
 }
 
 // GetWork mocks base method.
-func (m *Mockgetter) GetWork(ctx context.Context, workID int64, loadEditions editionsCallback) ([]byte, int64, error) {
+func (m *Mockgetter) GetWork(ctx context.Context, workID int64, saveEditions editionsCallback) ([]byte, int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetWork", ctx, workID, loadEditions)
+	ret := m.ctrl.Call(m, "GetWork", ctx, workID, saveEditions)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(int64)
 	ret2, _ := ret[2].(error)
@@ -170,9 +170,9 @@ func (m *Mockgetter) GetWork(ctx context.Context, workID int64, loadEditions edi
 }
 
 // GetWork indicates an expected call of GetWork.
-func (mr *MockgetterMockRecorder) GetWork(ctx, workID, loadEditions any) *MockgetterGetWorkCall {
+func (mr *MockgetterMockRecorder) GetWork(ctx, workID, saveEditions any) *MockgetterGetWorkCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWork", reflect.TypeOf((*Mockgetter)(nil).GetWork), ctx, workID, loadEditions)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWork", reflect.TypeOf((*Mockgetter)(nil).GetWork), ctx, workID, saveEditions)
 	return &MockgetterGetWorkCall{Call: call}
 }
 


### PR DESCRIPTION
Currently, loading the "best" edition of a work can trigger up to 20 additional fetches for other editions of the work. This contributes quite a lot to the backlog of things to load.

Instead, we can load those editions as part of the initial fetch by using a graphql fragment. We parse those fragments exactly the same as if we had fetched them separately, and our callback now simply denormalizes the data instead of scheduling a fetch.