### PR TITLE
Pull a few more fetches out of the denormalization step

### DIFF
--- a/cmd/rggr/main.go
+++ b/cmd/rggr/main.go
@@ -110,10 +110,10 @@ func (s *server) Run() error {
 	go func() {
 		<-shutdown
 		os.Exit(0)
-		//slog.Info("waiting for denormalization to finish")
-		//ctrl.Shutdown(ctx)
-		//slog.Info("shutting down http server")
-		//_ = server.Shutdown(ctx)
+		// slog.Info("waiting for denormalization to finish")
+		// ctrl.Shutdown(ctx)
+		// slog.Info("shutting down http server")
+		// _ = server.Shutdown(ctx)
 	}()
 
 	ctrl.Run(ctx, 2*time.Second)

--- a/cmd/rghc/main.go
+++ b/cmd/rghc/main.go
@@ -116,10 +116,10 @@ func (s *server) Run() error {
 	go func() {
 		<-shutdown
 		os.Exit(0)
-		//slog.Info("shutting down http server")
-		//_ = server.Shutdown(ctx)
-		//slog.Info("waiting for denormalization to finish")
-		//ctrl.Shutdown(ctx)
+		// slog.Info("shutting down http server")
+		// _ = server.Shutdown(ctx)
+		// slog.Info("waiting for denormalization to finish")
+		// ctrl.Shutdown(ctx)
 	}()
 
 	ctrl.Run(ctx, 2*time.Second)

--- a/internal/gr.go
+++ b/internal/gr.go
@@ -326,7 +326,7 @@ func (g *GRGetter) GetAuthor(ctx context.Context, authorID int64) ([]byte, error
 		Log(ctx).Debug("resolving author KCA", "authorID", authorID)
 		authorKCA, err = g.legacyAuthorIDtoKCA(ctx, authorID)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("resolving author: %w", err)
 		}
 	}
 
@@ -440,7 +440,7 @@ func (g *GRGetter) legacyAuthorIDtoKCA(ctx context.Context, authorID int64) (str
 
 	resp, err := g.upstream.Do(req)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("doing upstream: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 

--- a/internal/handler.go
+++ b/internal/handler.go
@@ -369,7 +369,7 @@ func (h *Handler) getAuthorID(w http.ResponseWriter, r *http.Request) {
 
 		author.Works = []workResource{work}
 
-		cacheFor(w, _authorTTL, true)
+		cacheFor(w, _editionTTL, true)
 		_ = json.NewEncoder(w).Encode(author)
 		return
 

--- a/internal/memory.go
+++ b/internal/memory.go
@@ -13,9 +13,9 @@ var _ cache[[]byte] = (*memoryCache)(nil)
 // newMemoryCache returns a new in-memory cache.
 func newMemoryCache() cache[[]byte] {
 	r, err := ristretto.NewCache(&ristretto.Config[string, []byte]{
-		NumCounters: 5e7,                                // Track LRU for up to 50M keys.
-		MaxCost:     3 * (debug.SetMemoryLimit(-1) / 4), // Use 75% of available memory.
-		BufferItems: 64,                                 // Number of keys per Get buffer.
+		NumCounters: 5e7,                          // Track LRU for up to 50M keys.
+		MaxCost:     debug.SetMemoryLimit(-1) / 2, // Use 75% of available memory.
+		BufferItems: 64,                           // Number of keys per Get buffer.
 	})
 	if err != nil {
 		panic(err)

--- a/internal/memory.go
+++ b/internal/memory.go
@@ -14,7 +14,7 @@ var _ cache[[]byte] = (*memoryCache)(nil)
 func newMemoryCache() cache[[]byte] {
 	r, err := ristretto.NewCache(&ristretto.Config[string, []byte]{
 		NumCounters: 5e7,                          // Track LRU for up to 50M keys.
-		MaxCost:     debug.SetMemoryLimit(-1) / 2, // Use 75% of available memory.
+		MaxCost:     debug.SetMemoryLimit(-1) / 2, // Use 50% of available memory.
 		BufferItems: 64,                           // Number of keys per Get buffer.
 	})
 	if err != nil {


### PR DESCRIPTION
This should ensure everything has already been fetched before we denormalize data. This is important because the denorm step is serialized (we don't want to add a work to an author before adding an edition to the work). In cases where those fetches are cache misses, it will enqueue redundant denorm steps but these will no-op. This could be optimized but in practice this change is sufficient to keep the denorm queue running smoothly.

The in-memory cache size is also reduced to 50% of available memory. 75% combined with a large backlog of things to refresh made it too easy to thrash GC.