### PR TITLE
Resume author refreshes after reboot

### DIFF
--- a/cmd/rggr/main.go
+++ b/cmd/rggr/main.go
@@ -72,7 +72,12 @@ func (s *server) Run() error {
 		return err
 	}
 
-	ctrl, err := internal.NewController(cache, getter)
+	persister, err := internal.NewPersister(ctx, s.DSN())
+	if err != nil {
+		return err
+	}
+
+	ctrl, err := internal.NewController(cache, getter, persister)
 	if err != nil {
 		return err
 	}

--- a/cmd/rghc/main.go
+++ b/cmd/rghc/main.go
@@ -78,7 +78,12 @@ func (s *server) Run() error {
 		return err
 	}
 
-	ctrl, err := internal.NewController(cache, getter)
+	persister, err := internal.NewPersister(ctx, s.DSN())
+	if err != nil {
+		return err
+	}
+
+	ctrl, err := internal.NewController(cache, getter, persister)
 	if err != nil {
 		return err
 	}

--- a/internal/controller.go
+++ b/internal/controller.go
@@ -63,9 +63,10 @@ func unknownAuthor(authorID int64) bool {
 // requested. We don't require a full database dump, so we're able to grab new
 // works as soon as they're available.
 type Controller struct {
-	cache  cache[[]byte]
-	getter getter             // Core GetBook/GetAuthor/GetWork implementation.
-	group  singleflight.Group // Coalesce lookups for the same key.
+	cache     cache[[]byte]
+	getter    getter             // Core GetBook/GetAuthor/GetWork implementation.
+	persister persister          // persister tracks state across reboots.
+	group     singleflight.Group // Coalesce lookups for the same key.
 
 	// denormC erializes denormalization updates. This should only be used when
 	// all resources have already been fetched.
@@ -142,10 +143,11 @@ func NewUpstream(host string, cookie string, proxy string) (*http.Client, error)
 
 // NewController creates a new controller. Background jobs to load author works
 // and editions is bounded to at most 10 concurrent tasks.
-func NewController(cache cache[[]byte], getter getter) (*Controller, error) {
+func NewController(cache cache[[]byte], getter getter, persister persister) (*Controller, error) {
 	c := &Controller{
-		cache:  cache,
-		getter: getter,
+		cache:     cache,
+		getter:    getter,
+		persister: persister,
 
 		denormC: make(chan edge),
 	}
@@ -164,6 +166,27 @@ func NewController(cache cache[[]byte], getter getter) (*Controller, error) {
 				"etagMatches", etagHits,
 				"etagRatio", float64(etagHits)/(float64(etagHits)+float64(etagMisses)),
 			)
+		}
+	}()
+
+	// Retry any author refreshes that were in-flight when we last shut down.
+	go func() {
+		ctx := context.WithValue(context.Background(), middleware.RequestIDKey, "recovery")
+
+		authorIDs, err := persister.Persisted(ctx)
+		if err != nil {
+			Log(ctx).Error("problem retrying in-flight refreshes", "err", err)
+		}
+		for _, authorID := range authorIDs {
+			c.refreshG.Go(func() error {
+				err := c.cache.Expire(ctx, AuthorKey(authorID))
+				if err != nil {
+					Log(ctx).Warn("problem expiring author", "err", err, "authorID", authorID)
+					return nil
+				}
+				_, _ = c.GetAuthor(ctx, authorID)
+				return nil
+			})
 		}
 	}()
 
@@ -381,8 +404,15 @@ func (c *Controller) getAuthor(ctx context.Context, authorID int64) ([]byte, err
 		c.refreshG.Go(func() error {
 			ctx := context.WithValue(context.Background(), middleware.RequestIDKey, fmt.Sprintf("refresh-author-%d", authorID))
 
+			if err := c.persister.Persist(ctx, authorID); err != nil {
+				Log(ctx).Warn("problem persisting refresh", "err", err)
+			}
+
 			defer func() {
 				c.refreshWaiting.Add(-1)
+				if err := c.persister.Delete(ctx, authorID); err != nil {
+					Log(ctx).Warn("problem un-persisting refresh", "err", err)
+				}
 				if r := recover(); r != nil {
 					Log(ctx).Error("panic", "details", r)
 				}

--- a/internal/controller_test.go
+++ b/internal/controller_test.go
@@ -45,7 +45,7 @@ func TestIncrementalDenormalization(t *testing.T) {
 
 	cache := newMemoryCache()
 
-	ctrl, err := NewController(cache, getter)
+	ctrl, err := NewController(cache, getter, nil)
 	require.NoError(t, err)
 
 	go func() {
@@ -168,7 +168,7 @@ func TestDenormalizeMissing(t *testing.T) {
 	notFoundGetter.EXPECT().GetAuthor(gomock.Any(), authorID).Return(nil, errNotFound).AnyTimes()
 	notFoundGetter.EXPECT().GetWork(gomock.Any(), workID, nil).Return(nil, 0, errNotFound).AnyTimes()
 
-	ctrl, err := NewController(cache, notFoundGetter)
+	ctrl, err := NewController(cache, notFoundGetter, nil)
 	require.NoError(t, err)
 
 	err = ctrl.denormalizeEditions(ctx, workID, bookID)
@@ -287,7 +287,7 @@ func TestSubtitles(t *testing.T) {
 
 	cache := newMemoryCache()
 
-	ctrl, err := NewController(cache, getter)
+	ctrl, err := NewController(cache, getter, nil)
 	require.NoError(t, err)
 
 	getter.EXPECT().GetAuthor(gomock.Any(), author.ForeignID).DoAndReturn(func(ctx context.Context, authorID int64) ([]byte, error) {
@@ -397,7 +397,7 @@ func TestSortedInvariant(t *testing.T) {
 	t.Run("denormalizeWorks", func(t *testing.T) {
 		c := gomock.NewController(t)
 		getter := NewMockgetter(c)
-		ctrl, err := NewController(cache, getter)
+		ctrl, err := NewController(cache, getter, nil)
 		require.NoError(t, err)
 
 		author := AuthorResource{
@@ -438,7 +438,7 @@ func TestSortedInvariant(t *testing.T) {
 	t.Run("denormalizeEditions", func(t *testing.T) {
 		c := gomock.NewController(t)
 		getter := NewMockgetter(c)
-		ctrl, err := NewController(cache, getter)
+		ctrl, err := NewController(cache, getter, nil)
 		require.NoError(t, err)
 
 		work := workResource{

--- a/internal/gr_test.go
+++ b/internal/gr_test.go
@@ -250,7 +250,7 @@ func TestGRGetBookDataIntegrity(t *testing.T) {
 	getter, err := NewGRGetter(cache, gql, &http.Client{Transport: upstream})
 	require.NoError(t, err)
 
-	ctrl, err := NewController(cache, getter)
+	ctrl, err := NewController(cache, getter, nil)
 	require.NoError(t, err)
 
 	go ctrl.Run(t.Context(), 0)
@@ -427,7 +427,7 @@ func TestAuth(t *testing.T) {
 
 	getter, err := NewGRGetter(cache, gql, upstream)
 	require.NoError(t, err)
-	ctrl, err := NewController(cache, getter)
+	ctrl, err := NewController(cache, getter, nil)
 	go ctrl.Run(t.Context(), time.Second)
 
 	require.NoError(t, err)

--- a/internal/hardcover_test.go
+++ b/internal/hardcover_test.go
@@ -229,7 +229,7 @@ func TestGetBookDataIntegrity(t *testing.T) {
 	getter, err := NewHardcoverGetter(cache, gql, &http.Client{Transport: upstream})
 	require.NoError(t, err)
 
-	ctrl, err := NewController(cache, getter)
+	ctrl, err := NewController(cache, getter, nil)
 	require.NoError(t, err)
 
 	go ctrl.Run(context.Background(), 0) // Denormalize data in the background.

--- a/internal/persist.go
+++ b/internal/persist.go
@@ -1,0 +1,72 @@
+package internal
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// persister records in-flight author refreshes so we can recover them on reboot.
+type persister interface {
+	Persist(ctx context.Context, authorID int64) error
+	Persisted(ctx context.Context) ([]int64, error)
+	Delete(ctx context.Context, authorID int64) error
+}
+
+// Persister tracks author refresh state across reboots.
+type Persister struct {
+	db *pgxpool.Pool
+}
+
+var _ persister = (*Persister)(nil)
+
+// NewPersister creates a new Persister.
+func NewPersister(ctx context.Context, dsn string) (*Persister, error) {
+	db, err := newDB(ctx, dsn)
+	return &Persister{db: db}, err
+}
+
+// Persist records an author's refresh as in-flight.
+func (p *Persister) Persist(ctx context.Context, authorID int64) error {
+	buf := make([]byte, 8)
+	_ = binary.PutVarint(buf, authorID)
+
+	_, err := p.db.Exec(ctx, "INSERT INTO cache (key, value) VALUES ($1, $2) ON CONFLICT DO NOTHING", fmt.Sprintf("ra%d", authorID), buf)
+	return err
+}
+
+// Delete records an in-flight refresh as completed.
+func (p *Persister) Delete(ctx context.Context, authorID int64) error {
+	_, err := p.db.Exec(ctx, "DELETE FROM cache WHERE key = $1", fmt.Sprintf("ra%d", authorID))
+	return err
+}
+
+// Persisted returns all in-flight author refreshes so they can be resumed.
+func (p *Persister) Persisted(ctx context.Context) ([]int64, error) {
+	rows, err := p.db.Query(ctx, "SELECT value FROM cache WHERE key LIKE $1", "ra%")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var authorIDs []int64
+
+	buf := make([]byte, 0, 8)
+	for rows.Next() {
+
+		err := rows.Scan(&buf)
+		if err != nil {
+			continue
+		}
+
+		authorID, err := binary.ReadVarint(bytes.NewReader(buf))
+		if err != nil {
+			continue
+		}
+		authorIDs = append(authorIDs, authorID)
+	}
+
+	return authorIDs, err
+}

--- a/internal/persist_test.go
+++ b/internal/persist_test.go
@@ -1,0 +1,35 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPersister(t *testing.T) {
+	ctx := t.Context()
+
+	dsn := "postgres://postgres@localhost:5432/test"
+
+	p, err := NewPersister(ctx, dsn)
+	require.NoError(t, err)
+
+	authorIDs, err := p.Persisted(ctx)
+	require.NoError(t, err)
+
+	assert.Empty(t, authorIDs)
+
+	assert.NoError(t, p.Persist(ctx, 2))
+	assert.NoError(t, p.Persist(ctx, 1))
+	assert.NoError(t, p.Persist(ctx, 1))
+
+	authorIDs, err = p.Persisted(ctx)
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, []int64{1, 2}, authorIDs)
+
+	assert.NoError(t, p.Delete(ctx, 1))
+	assert.NoError(t, p.Delete(ctx, 2))
+	assert.NoError(t, p.Delete(ctx, 10))
+}


### PR DESCRIPTION
Currently refreshing an author leaves it in an incomplete state until we've fetched all of their works and denormalized them to the author. If we shut down in the middle of that process the denorm step never happens, so the author seems like they have no works.

With this change we store a bit for each author currently being refreshed, and when we start up we check for those in-flight authors to start refreshing them again.

It's still possible when things are backed up for the refresh and denorm steps to happen very far apart, in which case users will see authors missing works.

Fixes https://github.com/blampe/rreading-glasses/issues/90