### PR TITLE
Write to db even on cancellation

### DIFF
--- a/cmd/rggr/main.go
+++ b/cmd/rggr/main.go
@@ -62,7 +62,7 @@ func (s *server) Run() error {
 	// interaction between these requests and the upstream HEAD requests
 	// elsewhere. Especially if those result in a 404. That seems to trigger
 	// the WAF, which blocks everything for a period of time.
-	gql, err := internal.NewGRGQL(ctx, upstream, s.Cookie, time.Second/2.0, 6)
+	gql, err := internal.NewGRGQL(ctx, upstream, s.Cookie, time.Second/2.0, 7)
 	if err != nil {
 		return err
 	}

--- a/internal/controller.go
+++ b/internal/controller.go
@@ -155,7 +155,7 @@ func NewController(cache cache[[]byte], getter getter, persister persister) (*Co
 		c.persister = persister
 	}
 
-	c.refreshG.SetLimit(10)
+	c.refreshG.SetLimit(15)
 
 	// Log controller stats every minute.
 	go func() {

--- a/internal/postgres.go
+++ b/internal/postgres.go
@@ -118,6 +118,11 @@ func (pg *pgcache) GetWithTTL(ctx context.Context, key string) ([]byte, time.Dur
 }
 
 func (pg *pgcache) Set(ctx context.Context, key string, val []byte, ttl time.Duration) {
+	// We intentionally ignore things like the request closing and killing our
+	// context, because if we've made it this far we definitely want to persist
+	// the data.
+	ctx = context.WithoutCancel(ctx)
+
 	expires := time.Now().Add(ttl)
 
 	buf := _buffers.Get()


### PR DESCRIPTION
We sometimes skip writing to the DB in the case where our context has been canceled e.g. due to request timeout. This is important data, since these timeouts are typically due to the 1s throttle we have on upstream requests.

Instead, if we have data to write we should always write it.