### PR TITLE
More aggressive edge grouping

### DIFF
--- a/internal/edges_test.go
+++ b/internal/edges_test.go
@@ -13,20 +13,24 @@ func TestGroupEdges(t *testing.T) {
 	go func() {
 		c <- edge{kind: authorEdge, parentID: 100, childIDs: []int64{1}}
 		c <- edge{kind: authorEdge, parentID: 100, childIDs: []int64{2, 3}}
-		c <- edge{kind: workEdge, parentID: 100, childIDs: []int64{4}}
+		c <- edge{kind: workEdge, parentID: 1000, childIDs: []int64{4}}
 		c <- edge{kind: authorEdge, parentID: 100, childIDs: []int64{5, 6}}
 		c <- edge{kind: authorEdge, parentID: 200, childIDs: []int64{7}}
 		c <- edge{kind: authorEdge, parentID: 100, childIDs: []int64{8}}
 		c <- edge{kind: authorEdge, parentID: 300, childIDs: []int64{9}}
+		c <- edge{kind: workEdge, parentID: 1000, childIDs: []int64{10}}
 		close(c)
 	}()
 
 	edges := slices.Collect(groupEdges(c, time.Second))
 
-	assert.Equal(t, edges[0], edge{kind: authorEdge, parentID: 100, childIDs: []int64{1, 2, 3}})
-	assert.Equal(t, edges[1], edge{kind: workEdge, parentID: 100, childIDs: []int64{4}})
-	assert.Equal(t, edges[2], edge{kind: authorEdge, parentID: 100, childIDs: []int64{5, 6}})
-	assert.Equal(t, edges[3], edge{kind: authorEdge, parentID: 200, childIDs: []int64{7}})
-	assert.Equal(t, edges[4], edge{kind: authorEdge, parentID: 100, childIDs: []int64{8}})
-	assert.Equal(t, edges[5], edge{kind: authorEdge, parentID: 300, childIDs: []int64{9}})
+	assert.Equal(t, edge{kind: workEdge, parentID: 1000, childIDs: []int64{4, 10}}, edges[0])
+
+	expected := []edge{
+		{kind: authorEdge, parentID: 100, childIDs: []int64{1, 2, 3, 5, 6, 8}},
+		{kind: authorEdge, parentID: 200, childIDs: []int64{7}},
+		{kind: authorEdge, parentID: 300, childIDs: []int64{9}},
+	}
+
+	assert.ElementsMatch(t, expected, edges[1:])
 }


### PR DESCRIPTION
Denorm is dominated by unmarshaling, so accumulate edges for a second to allow better grouping.