### PR TITLE
Preserve audiobook editions on the work

### DIFF
--- a/internal/gr.go
+++ b/internal/gr.go
@@ -185,7 +185,11 @@ func (g *GRGetter) GetBook(ctx context.Context, bookID int64, saveEditions editi
 	if saveEditions != nil && workRsc.BestBookID == bookID {
 		editions := map[editionDedupe]workResource{}
 		for _, e := range work.Editions.Edges {
-			key := editionDedupe{title: strings.ToUpper(e.Node.Title), language: iso639_3(e.Node.Details.Language.Name)}
+			key := editionDedupe{
+				title:    strings.ToUpper(e.Node.Title),
+				language: iso639_3(e.Node.Details.Language.Name),
+				audio:    e.Node.Details.Format == "Audible Audio",
+			}
 			edition := e.Node.BookInfo
 			if _, ok := editions[key]; ok {
 				continue // Already saw an edition similar to this one.
@@ -510,4 +514,5 @@ func releaseDate(t float64) string {
 type editionDedupe struct {
 	title    string
 	language string
+	audio    bool
 }

--- a/internal/gr_test.go
+++ b/internal/gr_test.go
@@ -203,6 +203,20 @@ func TestGRGetBookDataIntegrity(t *testing.T) {
 								{
 									Node: gr.GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook{
 										BookInfo: gr.BookInfo{
+											LegacyId: 6609767, // Should be included since this is an audiobook.
+											Title:    "OUT OF MY MIND",
+											Details: gr.BookInfoDetailsBookDetails{
+												Format: "Audible Audio",
+												Language: gr.BookInfoDetailsBookDetailsLanguage{
+													Name: "English",
+												},
+											},
+										},
+									},
+								},
+								{
+									Node: gr.GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook{
+										BookInfo: gr.BookInfo{
 											LegacyId: 6609766, // Should be included since it's a different language.
 											Title:    "Some other edition",
 											Details: gr.BookInfoDetailsBookDetails{
@@ -288,7 +302,7 @@ func TestGRGetBookDataIntegrity(t *testing.T) {
 		assert.Equal(t, int64(51942), author.ForeignID)
 		require.Len(t, author.Works, 1)
 		require.Len(t, author.Works[0].Authors, 1)
-		require.Len(t, author.Works[0].Books, 2, author.Works[0].Books)
+		require.Len(t, author.Works[0].Books, 3, author.Works[0].Books)
 	})
 
 	t.Run("GetWork", func(t *testing.T) {
@@ -311,9 +325,10 @@ func TestGRGetBookDataIntegrity(t *testing.T) {
 		assert.Equal(t, int64(51942), work.Authors[0].ForeignID)
 		require.Len(t, work.Authors[0].Works, 1)
 
-		require.Len(t, work.Books, 2)
+		require.Len(t, work.Books, 3)
 		assert.Equal(t, int64(6609765), work.Books[0].ForeignID)
 		assert.Equal(t, int64(6609766), work.Books[1].ForeignID)
+		assert.Equal(t, int64(6609767), work.Books[2].ForeignID)
 	})
 }
 


### PR DESCRIPTION
Instead of deduplicating them if they happen to have the same title/language as a different edition.

This will make it easier to surface narrator information in the work, when we start pulling secondary contributor edges.