### PR TITLE
Upgrade to go 1.25rc2

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-export GOTOOLCHAIN=go1.24.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.24.3-alpine AS build
+FROM --platform=$BUILDPLATFORM golang:1.25rc2-alpine AS build
 
 WORKDIR /app
 COPY go.mod go.sum ./
@@ -10,7 +10,7 @@ ARG TARGETOS
 ARG TARGETARCH
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOEXPERIMENT=greenteagc \
     go build -o /app/main -ldflags="-w -s" ${RGPATH}
 
 FROM gcr.io/distroless/static:nonroot AS app

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/blampe/rreading-glasses
 
-go 1.24.2
+go 1.25rc2
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/Khan/genqlient v0.8.1 h1:wtOCc8N9rNynRLXN3k3CnfzheCUNKBcvXmVv5zt6WCs=
 github.com/Khan/genqlient v0.8.1/go.mod h1:R2G6DzjBvCbhjsEajfRjbWdVglSH/73kSivC9TLWVjU=
-github.com/KimMachineGun/automemlimit v0.7.2 h1:DyfHI7zLWmZPn2Wqdy2AgTiUvrGPmnYWgwhHXtAegX4=
-github.com/KimMachineGun/automemlimit v0.7.2/go.mod h1:QZxpHaGOQoYvFhv/r4u3U0JTC2ZcOwbSr11UZF46UBM=
 github.com/KimMachineGun/automemlimit v0.7.4 h1:UY7QYOIfrr3wjjOAqahFmC3IaQCLWvur9nmfIn6LnWk=
 github.com/KimMachineGun/automemlimit v0.7.4/go.mod h1:QZxpHaGOQoYvFhv/r4u3U0JTC2ZcOwbSr11UZF46UBM=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=


### PR DESCRIPTION
This upgrades Go to 1.25rc2 which includes a new garbage collector.

GC shows up in profiles when we have a large number of goroutines, so it's worth trying to see if this helps.

Waiting on sonic and golangci-lint.