### PR TITLE
Fix an issue where authors could lose books during refresh

### DIFF
--- a/cmd/rggr/main.go
+++ b/cmd/rggr/main.go
@@ -72,7 +72,7 @@ func (s *server) Run() error {
 		return err
 	}
 
-	persister, err := internal.NewPersister(ctx, s.DSN())
+	persister, err := internal.NewPersister(ctx, cache, s.DSN())
 	if err != nil {
 		return err
 	}

--- a/cmd/rghc/main.go
+++ b/cmd/rghc/main.go
@@ -78,7 +78,7 @@ func (s *server) Run() error {
 		return err
 	}
 
-	persister, err := internal.NewPersister(ctx, s.DSN())
+	persister, err := internal.NewPersister(ctx, cache, s.DSN())
 	if err != nil {
 		return err
 	}

--- a/internal/cache.go
+++ b/internal/cache.go
@@ -14,6 +14,7 @@ type cache[T any] interface {
 	GetWithTTL(ctx context.Context, key string) (T, time.Duration, bool)
 	Set(ctx context.Context, key string, value T, ttl time.Duration)
 	Expire(ctx context.Context, key string) error
+	Delete(ctx context.Context, key string) error
 }
 
 // LayeredCache implements a simple tiered cache. In practice we use an
@@ -74,6 +75,16 @@ func (c *LayeredCache) Expire(ctx context.Context, key string) error {
 	var err error
 	for _, cc := range c.wrapped {
 		err = errors.Join(cc.Expire(ctx, key))
+	}
+	return err
+}
+
+// Delete deletes a key from all layers of the cache. Expire should typically
+// be used instead.
+func (c *LayeredCache) Delete(ctx context.Context, key string) error {
+	var err error
+	for _, cc := range c.wrapped {
+		err = errors.Join(cc.Delete(ctx, key))
 	}
 	return err
 }

--- a/internal/controller_test.go
+++ b/internal/controller_test.go
@@ -300,7 +300,7 @@ func TestSubtitles(t *testing.T) {
 		return initialAuthorBytes, nil
 	}).AnyTimes()
 
-	getter.EXPECT().GetWork(gomock.Any(), workDupe1.ForeignID, nil).DoAndReturn(func(ctx context.Context, workID int64, saveEditions editionsCallback) ([]byte, int64, error) {
+	getter.EXPECT().GetWork(gomock.Any(), workDupe1.ForeignID, gomock.Any()).DoAndReturn(func(ctx context.Context, workID int64, saveEditions editionsCallback) ([]byte, int64, error) {
 		cachedBytes, ok := ctrl.cache.Get(ctx, WorkKey(workID))
 		if ok {
 			return cachedBytes, 0, nil
@@ -308,7 +308,7 @@ func TestSubtitles(t *testing.T) {
 		return initialWorkDupe1Bytes, author.ForeignID, nil
 	}).AnyTimes()
 
-	getter.EXPECT().GetWork(gomock.Any(), workDupe2.ForeignID, nil).DoAndReturn(func(ctx context.Context, workID int64, saveEditions editionsCallback) ([]byte, int64, error) {
+	getter.EXPECT().GetWork(gomock.Any(), workDupe2.ForeignID, gomock.Any()).DoAndReturn(func(ctx context.Context, workID int64, saveEditions editionsCallback) ([]byte, int64, error) {
 		cachedBytes, ok := ctrl.cache.Get(ctx, WorkKey(workID))
 		if ok {
 			return cachedBytes, 0, nil
@@ -316,7 +316,7 @@ func TestSubtitles(t *testing.T) {
 		return initialWorkDupe2Bytes, author.ForeignID, nil
 	}).AnyTimes()
 
-	getter.EXPECT().GetWork(gomock.Any(), workDupe3.ForeignID, nil).DoAndReturn(func(ctx context.Context, workID int64, saveEditions editionsCallback) ([]byte, int64, error) {
+	getter.EXPECT().GetWork(gomock.Any(), workDupe3.ForeignID, gomock.Any()).DoAndReturn(func(ctx context.Context, workID int64, saveEditions editionsCallback) ([]byte, int64, error) {
 		cachedBytes, ok := ctrl.cache.Get(ctx, WorkKey(workID))
 		if ok {
 			return cachedBytes, 0, nil
@@ -324,7 +324,7 @@ func TestSubtitles(t *testing.T) {
 		return initialWorkDupe3Bytes, author.ForeignID, nil
 	}).AnyTimes()
 
-	getter.EXPECT().GetWork(gomock.Any(), workDupe4.ForeignID, nil).DoAndReturn(func(ctx context.Context, workID int64, saveEditions editionsCallback) ([]byte, int64, error) {
+	getter.EXPECT().GetWork(gomock.Any(), workDupe4.ForeignID, gomock.Any()).DoAndReturn(func(ctx context.Context, workID int64, saveEditions editionsCallback) ([]byte, int64, error) {
 		cachedBytes, ok := ctrl.cache.Get(ctx, WorkKey(workID))
 		if ok {
 			return cachedBytes, 0, nil
@@ -332,7 +332,7 @@ func TestSubtitles(t *testing.T) {
 		return initialWorkDupe4Bytes, author.ForeignID, nil
 	}).AnyTimes()
 
-	getter.EXPECT().GetWork(gomock.Any(), workUnique.ForeignID, nil).DoAndReturn(func(ctx context.Context, workID int64, saveEditions editionsCallback) ([]byte, int64, error) {
+	getter.EXPECT().GetWork(gomock.Any(), workUnique.ForeignID, gomock.Any()).DoAndReturn(func(ctx context.Context, workID int64, saveEditions editionsCallback) ([]byte, int64, error) {
 		cachedBytes, ok := ctrl.cache.Get(ctx, WorkKey(workID))
 		if ok {
 			return cachedBytes, 0, nil
@@ -340,7 +340,7 @@ func TestSubtitles(t *testing.T) {
 		return initialWorkUniqueBytes, author.ForeignID, nil
 	}).AnyTimes()
 
-	getter.EXPECT().GetWork(gomock.Any(), workSeries.ForeignID, nil).DoAndReturn(func(ctx context.Context, workID int64, saveEditions editionsCallback) ([]byte, int64, error) {
+	getter.EXPECT().GetWork(gomock.Any(), workSeries.ForeignID, gomock.Any()).DoAndReturn(func(ctx context.Context, workID int64, saveEditions editionsCallback) ([]byte, int64, error) {
 		cachedBytes, ok := ctrl.cache.Get(ctx, WorkKey(workID))
 		if ok {
 			return cachedBytes, 0, nil

--- a/internal/memory.go
+++ b/internal/memory.go
@@ -47,3 +47,7 @@ func (c *memoryCache) Expire(_ context.Context, key string) error {
 	c.r.Del(key)
 	return nil
 }
+
+func (c *memoryCache) Delete(ctx context.Context, key string) error {
+	return c.Expire(ctx, key)
+}

--- a/internal/persist.go
+++ b/internal/persist.go
@@ -5,20 +5,22 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // persister records in-flight author refreshes so we can recover them on reboot.
 type persister interface {
-	Persist(ctx context.Context, authorID int64) error
+	Persist(ctx context.Context, authorID int64, current []byte) error
 	Persisted(ctx context.Context) ([]int64, error)
 	Delete(ctx context.Context, authorID int64) error
 }
 
 // Persister tracks author refresh state across reboots.
 type Persister struct {
-	db *pgxpool.Pool
+	db    *pgxpool.Pool
+	cache cache[[]byte]
 }
 
 // nopersist no-ops persistence for tests.
@@ -29,7 +31,7 @@ var (
 	_ persister = (*nopersist)(nil)
 )
 
-func (*nopersist) Persist(ctx context.Context, authorID int64) error {
+func (*nopersist) Persist(ctx context.Context, authorID int64, current []byte) error {
 	return nil
 }
 
@@ -42,24 +44,20 @@ func (*nopersist) Delete(ctx context.Context, authorID int64) error {
 }
 
 // NewPersister creates a new Persister.
-func NewPersister(ctx context.Context, dsn string) (*Persister, error) {
+func NewPersister(ctx context.Context, cache cache[[]byte], dsn string) (*Persister, error) {
 	db, err := newDB(ctx, dsn)
-	return &Persister{db: db}, err
+	return &Persister{db: db, cache: cache}, err
 }
 
 // Persist records an author's refresh as in-flight.
-func (p *Persister) Persist(ctx context.Context, authorID int64) error {
-	buf := make([]byte, 8)
-	_ = binary.PutVarint(buf, authorID)
-
-	_, err := p.db.Exec(ctx, "INSERT INTO cache (key, value) VALUES ($1, $2) ON CONFLICT DO NOTHING", fmt.Sprintf("ra%d", authorID), buf)
-	return err
+func (p *Persister) Persist(ctx context.Context, authorID int64, bytes []byte) error {
+	p.cache.Set(ctx, refreshAuthorKey(authorID), bytes, 365*24*time.Hour)
+	return nil
 }
 
 // Delete records an in-flight refresh as completed.
 func (p *Persister) Delete(ctx context.Context, authorID int64) error {
-	_, err := p.db.Exec(ctx, "DELETE FROM cache WHERE key = $1", fmt.Sprintf("ra%d", authorID))
-	return err
+	return p.cache.Delete(ctx, refreshAuthorKey(authorID))
 }
 
 // Persisted returns all in-flight author refreshes so they can be resumed.
@@ -87,4 +85,8 @@ func (p *Persister) Persisted(ctx context.Context) ([]int64, error) {
 	}
 
 	return authorIDs, err
+}
+
+func refreshAuthorKey(authorID int64) string {
+	return fmt.Sprintf("ra%d", authorID)
 }

--- a/internal/persist_test.go
+++ b/internal/persist_test.go
@@ -11,8 +11,10 @@ func TestPersister(t *testing.T) {
 	ctx := t.Context()
 
 	dsn := "postgres://postgres@localhost:5432/test"
+	cache, err := NewCache(t.Context(), dsn)
+	require.NoError(t, err)
 
-	p, err := NewPersister(ctx, dsn)
+	p, err := NewPersister(ctx, cache, dsn)
 	require.NoError(t, err)
 
 	authorIDs, err := p.Persisted(ctx)
@@ -20,9 +22,9 @@ func TestPersister(t *testing.T) {
 
 	assert.Empty(t, authorIDs)
 
-	assert.NoError(t, p.Persist(ctx, 2))
-	assert.NoError(t, p.Persist(ctx, 1))
-	assert.NoError(t, p.Persist(ctx, 1))
+	assert.NoError(t, p.Persist(ctx, 2, _missing))
+	assert.NoError(t, p.Persist(ctx, 1, _missing))
+	assert.NoError(t, p.Persist(ctx, 1, _missing))
 
 	authorIDs, err = p.Persisted(ctx)
 	require.NoError(t, err)

--- a/internal/postgres.go
+++ b/internal/postgres.go
@@ -141,9 +141,15 @@ func (pg *pgcache) Set(ctx context.Context, key string, val []byte, ttl time.Dur
 	}
 }
 
-// Expire can expire a row if provided the key as a tag.
+// Expire expires a row by setting its ttl to 0. The data is still persisted.
 func (pg *pgcache) Expire(ctx context.Context, key string) error {
 	_, err := pg.db.Exec(ctx, `UPDATE cache SET expires = $1 WHERE key = $2;`, time.UnixMicro(0), key)
+	return err
+}
+
+// Delete deletes a row.
+func (pg *pgcache) Delete(ctx context.Context, key string) error {
+	_, err := pg.db.Exec(ctx, `DELETE FROM cache WHERE key = $1;`, key)
 	return err
 }
 


### PR DESCRIPTION
If an author took a long time to refresh (e.g. due to a backlog of other work) we would end up returning the partial (one-book) author. Users would see this as the author's works disappearing.

This PR fixes that by storing the author's last-known state along with the fact that the author is being refreshed. We return that last-known state for the entire duration of the refresh.

Fixes https://github.com/blampe/rreading-glasses/issues/173.