### PR TITLE
Fix fuzzing

### DIFF
--- a/internal/controller.go
+++ b/internal/controller.go
@@ -801,9 +801,10 @@ func (c *Controller) denormalizeWorks(ctx context.Context, authorID int64, workI
 // additional editions.
 type editionsCallback func(...workResource)
 
+// fuzz scales the given duration into the range (d, d * f).
 func fuzz(d time.Duration, f float64) time.Duration {
-	if f > 1.0 {
-		f = 1.0
+	if f < 1.0 {
+		f += 1.0
 	}
 	factor := 1.0 + rand.Float64()*(f-1.0)
 	return time.Duration(float64(d) * factor)

--- a/internal/controller_test.go
+++ b/internal/controller_test.go
@@ -484,6 +484,12 @@ func TestSortedInvariant(t *testing.T) {
 	})
 }
 
+func TestFuzz(t *testing.T) {
+	fuzzed := fuzz(_authorTTL, 2)
+	assert.Less(t, fuzzed, _authorTTL * 2)
+	assert.Greater(t, fuzzed, _authorTTL)
+}
+
 func waitForDenorm(ctrl *Controller) {
 	for !ctrl.refreshG.TryGo(func() error { return nil }) {
 		time.Sleep(100 * time.Millisecond)


### PR DESCRIPTION
I guess I initially wrote the function to behave like the multiplier was `(1 + f)` but then started using it like the multiplier was just `f`. That caused fuzzing to not actually happen, so update the function to behave as expected and add a test.