### PR TITLE
Fix stale data return

### DIFF
--- a/internal/cache.go
+++ b/internal/cache.go
@@ -10,8 +10,8 @@ import (
 )
 
 type cache[T any] interface {
-	Get(ctx context.Context, key string) (T, bool)
-	GetWithTTL(ctx context.Context, key string) (T, time.Duration, bool)
+	Get(ctx context.Context, key string) (T, bool) // bool should be true if data was found.
+	GetWithTTL(ctx context.Context, key string) (T, time.Duration, bool) // bool should be true if data was found.
 	Set(ctx context.Context, key string, value T, ttl time.Duration)
 	Expire(ctx context.Context, key string) error
 	Delete(ctx context.Context, key string) error
@@ -45,7 +45,7 @@ func (c *LayeredCache) GetWithTTL(ctx context.Context, key string) ([]byte, time
 		if !ok {
 			// Percolate the value back up if we eventually find it.
 			defer func(cc cache[[]byte]) {
-				if val == nil {
+				if len(val) == 0 {
 					return
 				}
 				cc.Set(ctx, key, val, ttl)

--- a/internal/controller_test.go
+++ b/internal/controller_test.go
@@ -82,7 +82,7 @@ func TestIncrementalDenormalization(t *testing.T) {
 		if ok {
 			return cachedBytes, 0, nil
 		}
-		return initialWorkBytes, author.ForeignID, nil
+		return initialWorkBytes, authorID, nil
 	}).AnyTimes()
 
 	getter.EXPECT().GetAuthorBooks(gomock.Any(), authorID).Return(
@@ -486,7 +486,7 @@ func TestSortedInvariant(t *testing.T) {
 
 func TestFuzz(t *testing.T) {
 	fuzzed := fuzz(_authorTTL, 2)
-	assert.Less(t, fuzzed, _authorTTL * 2)
+	assert.Less(t, fuzzed, _authorTTL*2)
 	assert.Greater(t, fuzzed, _authorTTL)
 }
 

--- a/internal/postgres.go
+++ b/internal/postgres.go
@@ -111,7 +111,7 @@ func (pg *pgcache) GetWithTTL(ctx context.Context, key string) ([]byte, time.Dur
 	// the cached data because it can help speed up the refresh.
 	ttl := time.Until(expires)
 	if ttl <= 0 {
-		return uncompressed, 0, false
+		return uncompressed, 0, true
 	}
 
 	return uncompressed, ttl, true


### PR DESCRIPTION
Expired data was still being returned as `data, false` which was causing refresh logic to perform cold lookups instead of re-using KCAs. (Cold lookups are extremely slow.)

This fixes the PG cache so the bool param is always true whenever data was found. The ttl should be checked separately for expired-ness.