### PR TITLE
Prefer FIFO order when recovering in-flight author refreshes

### DIFF
--- a/internal/cache.go
+++ b/internal/cache.go
@@ -10,7 +10,7 @@ import (
 )
 
 type cache[T any] interface {
-	Get(ctx context.Context, key string) (T, bool) // bool should be true if data was found.
+	Get(ctx context.Context, key string) (T, bool)                       // bool should be true if data was found.
 	GetWithTTL(ctx context.Context, key string) (T, time.Duration, bool) // bool should be true if data was found.
 	Set(ctx context.Context, key string, value T, ttl time.Duration)
 	Expire(ctx context.Context, key string) error

--- a/internal/gr_test.go
+++ b/internal/gr_test.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -294,11 +293,6 @@ func TestGRGetBookDataIntegrity(t *testing.T) {
 		waitForDenorm(ctrl)
 
 		authorBytes, ttl, err := ctrl.GetAuthor(ctx, 51942)
-		if errors.Is(err, errNotFound) {
-			// This call seems to flake on CI a bunch -- retry in that case.
-			time.Sleep(time.Second)
-			authorBytes, ttl, err = ctrl.GetAuthor(ctx, 51942)
-		}
 		require.NoError(t, err)
 		assert.NotZero(t, ttl)
 

--- a/internal/gr_test.go
+++ b/internal/gr_test.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -293,6 +294,11 @@ func TestGRGetBookDataIntegrity(t *testing.T) {
 		waitForDenorm(ctrl)
 
 		authorBytes, ttl, err := ctrl.GetAuthor(ctx, 51942)
+		if errors.Is(err, errNotFound) {
+			// This call seems to flake on CI a bunch -- retry in that case.
+			time.Sleep(time.Second)
+			authorBytes, ttl, err = ctrl.GetAuthor(ctx, 51942)
+		}
 		require.NoError(t, err)
 		assert.NotZero(t, ttl)
 

--- a/internal/persist_test.go
+++ b/internal/persist_test.go
@@ -25,13 +25,15 @@ func TestPersister(t *testing.T) {
 	assert.NoError(t, p.Persist(ctx, 2, _missing))
 	assert.NoError(t, p.Persist(ctx, 1, _missing))
 	assert.NoError(t, p.Persist(ctx, 1, _missing))
+	assert.NoError(t, p.Persist(ctx, 3, _missing))
 
 	authorIDs, err = p.Persisted(ctx)
 	require.NoError(t, err)
 
-	assert.ElementsMatch(t, []int64{1, 2}, authorIDs)
+	assert.Equal(t, []int64{2, 1, 3}, authorIDs)
 
 	assert.NoError(t, p.Delete(ctx, 1))
 	assert.NoError(t, p.Delete(ctx, 2))
+	assert.NoError(t, p.Delete(ctx, 3))
 	assert.NoError(t, p.Delete(ctx, 10))
 }


### PR DESCRIPTION
Sort recovered author refreshes so oldest are processed first.

I could do this more efficiently as part of the query, but I don't have a compound index on (key, expires) and I'd rather not deal with a migration if it can be avoided. I also don't think the overhead is worth it for such a minor use case.