### PR TITLE
Buffer denorms in memory

### DIFF
--- a/internal/controller_test.go
+++ b/internal/controller_test.go
@@ -147,7 +147,7 @@ func TestIncrementalDenormalization(t *testing.T) {
 	_ = ctrl.cache.Expire(ctx, AuthorKey(author.ForeignID))
 	_, _, _ = ctrl.GetAuthor(ctx, author.ForeignID)
 
-	_ = ctrl.refreshG.Wait()
+	waitForDenorm(ctrl)
 	time.Sleep(100 * time.Millisecond) // Wait for the denormalization goroutine update things.
 
 	authorBytes, _, err = ctrl.GetAuthor(ctx, author.ForeignID)

--- a/internal/controller_test.go
+++ b/internal/controller_test.go
@@ -117,6 +117,8 @@ func TestIncrementalDenormalization(t *testing.T) {
 	require.NoError(t, json.Unmarshal(workBytes, &w))
 	assert.Len(t, w.Books, 2)
 
+	waitForDenorm(ctrl)
+
 	// The work should have also been updated on the author.
 	authorBytes, _, err = ctrl.GetAuthor(ctx, author.ForeignID)
 	require.NoError(t, err)
@@ -148,7 +150,6 @@ func TestIncrementalDenormalization(t *testing.T) {
 	_, _, _ = ctrl.GetAuthor(ctx, author.ForeignID)
 
 	waitForDenorm(ctrl)
-	time.Sleep(100 * time.Millisecond) // Wait for the denormalization goroutine update things.
 
 	authorBytes, _, err = ctrl.GetAuthor(ctx, author.ForeignID)
 	require.NoError(t, err)

--- a/internal/controller_test.go
+++ b/internal/controller_test.go
@@ -494,6 +494,9 @@ func waitForDenorm(ctrl *Controller) {
 	for !ctrl.refreshG.TryGo(func() error { return nil }) {
 		time.Sleep(100 * time.Millisecond)
 	}
+	for ctrl.denormWaiting.Load() != 0 {
+		time.Sleep(100 * time.Millisecond)
+	}
 
 	if os.Getenv("CI") != "" {
 		time.Sleep(1 * time.Second)

--- a/internal/edges.go
+++ b/internal/edges.go
@@ -1,9 +1,9 @@
 package internal
 
 import (
-	"context"
 	"iter"
-	"time"
+	"maps"
+	"sync"
 )
 
 type edgeKind int
@@ -17,7 +17,7 @@ const (
 type edge struct {
 	kind     edgeKind
 	parentID int64
-	childIDs []int64
+	childIDs set[int64]
 }
 
 // groupEdges collects edges of the same kind and parent together in order to
@@ -25,44 +25,116 @@ type edge struct {
 //
 // If an edge isn't seen after the wait duration then we yield the last edge we
 // saw.
-func groupEdges(ctx context.Context, edges chan edge, wait time.Duration) iter.Seq[edge] {
+func groupEdges(edges chan edge) iter.Seq[edge] {
+	buffer := &edgebuf{
+		queue:   []*edge{},
+		works:   map[int64]*edge{},
+		authors: map[int64]*edge{},
+	}
+	buffer.cond = sync.NewCond(&buffer.mu)
+
+	go func() {
+		for e := range edges {
+			buffer.push(&e)
+		}
+		buffer.close()
+	}()
+
 	return func(yield func(edge) bool) {
-		var next edge
-		var ok bool
-
-		edge := <-edges
 		for {
-			select {
-			case next, ok = <-edges:
-				if !ok {
-					// Channel is closed.
-					_ = yield(edge)
-					return
-				}
-			case <-time.After(wait):
-				if !yield(edge) {
-					return
-				}
-				// Wait until we see the next edge, then start over.
-				edge = <-edges
-				continue
-			case <-ctx.Done():
+			edge, ok := buffer.pop()
+			if !ok {
 				return
 			}
-
-			// If the next edge is for the same parent and kind, then aggregate
-			// its children into ours and move on.
-			if edge.parentID == next.parentID && edge.kind == next.kind {
-				edge.childIDs = append(edge.childIDs, next.childIDs...)
-				continue
-			}
-
-			// Next edge is for a different parent, so yield our current edge.
-			if !yield(edge) {
+			if !yield(*edge) {
 				return
 			}
-
-			edge = next
 		}
 	}
+}
+
+type set[T comparable] map[T]struct{}
+
+func newSet[T comparable](ts ...T) set[T] {
+	s := set[T]{}
+	for _, t := range ts {
+		s[t] = struct{}{}
+	}
+	return s
+}
+
+func union[T comparable, S set[T]](x S, y S) S {
+	r := maps.Clone(x)
+	maps.Copy(r, y)
+	return r
+}
+
+type edgebuf struct {
+	mu      sync.Mutex
+	cond    *sync.Cond
+	queue   []*edge
+	works   map[int64]*edge
+	authors map[int64]*edge
+
+	closed bool
+}
+
+func (b *edgebuf) push(e *edge) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	var existing *edge
+	var ok bool
+
+	switch e.kind {
+	case authorEdge:
+		existing, ok = b.authors[e.parentID]
+		if !ok {
+			b.authors[e.parentID] = e
+		}
+	case workEdge:
+		existing, ok = b.works[e.parentID]
+		if !ok {
+			b.works[e.parentID] = e
+		}
+	}
+	if ok {
+		existing.childIDs = union(existing.childIDs, e.childIDs)
+	} else {
+		b.queue = append(b.queue, e)
+	}
+	b.cond.Signal()
+}
+
+func (b *edgebuf) pop() (*edge, bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	for len(b.queue) == 0 && !b.closed {
+		b.cond.Wait()
+	}
+
+	if len(b.queue) == 0 {
+		return nil, false
+	}
+
+	edge := b.queue[0]
+	b.queue = b.queue[1:]
+
+	switch edge.kind {
+	case authorEdge:
+		delete(b.authors, edge.parentID)
+	case workEdge:
+		delete(b.works, edge.parentID)
+	}
+
+	return edge, true
+}
+
+func (b *edgebuf) close() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.closed = true
+	b.cond.Broadcast()
 }

--- a/internal/gr_test.go
+++ b/internal/gr_test.go
@@ -289,7 +289,6 @@ func TestGRGetBookDataIntegrity(t *testing.T) {
 		assert.Equal(t, "eng", work.Books[0].Language)
 	})
 
-
 	t.Run("GetWork", func(t *testing.T) {
 		// Make sure our cache is empty so we actually exercise the work refresh.
 		require.NoError(t, ctrl.cache.Expire(t.Context(), WorkKey(6803732)))


### PR DESCRIPTION
We serialize all denormalization steps through a channel to prevent a work attaching to an author before an edition attaches to the work.

Currently we spawn goroutines which wait until their turn to add to this channel, but when the backlog is very large this can create hundreds of thousands of idle goroutines. At that point performance begins to degrade and CPU usage spikes due to most of our time being spent finding goroutines to wake up.

This change immediately accepts writes to the channel but then buffers them in memory before performing the denormalization. This is cheap in terms of memory and it keeps CPU consistently in the ~30% with a full backlog of work.

The buffer itself is an array of edges in the same order we pulled them off the channel, along with indices into that array so we can de-dupe operations on the same author/work. So as a side effect we also get much smarter edge grouping behavior, which is helpful for reducing deserializations.

The in-memory buffer isn't persisted across reboots, but this hasn't been noticed by users and refreshing an author is a reasonable workaround for now.