### PR TITLE
Ignore editions not attributed to the work's author

### DIFF
--- a/gr/generated.go
+++ b/gr/generated.go
@@ -512,9 +512,10 @@ func (v *GetBookGetBookByLegacyIdBookWork) GetEditions() GetBookGetBookByLegacyI
 
 // GetBookGetBookByLegacyIdBookWorkBestBook includes the requested fields of the GraphQL type Book.
 type GetBookGetBookByLegacyIdBookWorkBestBook struct {
-	LegacyId     int64  `json:"legacyId"`
-	Title        string `json:"title"`
-	TitlePrimary string `json:"titlePrimary"`
+	LegacyId               int64                                                                             `json:"legacyId"`
+	Title                  string                                                                            `json:"title"`
+	TitlePrimary           string                                                                            `json:"titlePrimary"`
+	PrimaryContributorEdge GetBookGetBookByLegacyIdBookWorkBestBookPrimaryContributorEdgeBookContributorEdge `json:"primaryContributorEdge"`
 }
 
 // GetLegacyId returns GetBookGetBookByLegacyIdBookWorkBestBook.LegacyId, and is useful for accessing the field via an interface.
@@ -525,6 +526,37 @@ func (v *GetBookGetBookByLegacyIdBookWorkBestBook) GetTitle() string { return v.
 
 // GetTitlePrimary returns GetBookGetBookByLegacyIdBookWorkBestBook.TitlePrimary, and is useful for accessing the field via an interface.
 func (v *GetBookGetBookByLegacyIdBookWorkBestBook) GetTitlePrimary() string { return v.TitlePrimary }
+
+// GetPrimaryContributorEdge returns GetBookGetBookByLegacyIdBookWorkBestBook.PrimaryContributorEdge, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBookWorkBestBook) GetPrimaryContributorEdge() GetBookGetBookByLegacyIdBookWorkBestBookPrimaryContributorEdgeBookContributorEdge {
+	return v.PrimaryContributorEdge
+}
+
+// GetBookGetBookByLegacyIdBookWorkBestBookPrimaryContributorEdgeBookContributorEdge includes the requested fields of the GraphQL type BookContributorEdge.
+type GetBookGetBookByLegacyIdBookWorkBestBookPrimaryContributorEdgeBookContributorEdge struct {
+	Role string                                                                                           `json:"role"`
+	Node GetBookGetBookByLegacyIdBookWorkBestBookPrimaryContributorEdgeBookContributorEdgeNodeContributor `json:"node"`
+}
+
+// GetRole returns GetBookGetBookByLegacyIdBookWorkBestBookPrimaryContributorEdgeBookContributorEdge.Role, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBookWorkBestBookPrimaryContributorEdgeBookContributorEdge) GetRole() string {
+	return v.Role
+}
+
+// GetNode returns GetBookGetBookByLegacyIdBookWorkBestBookPrimaryContributorEdgeBookContributorEdge.Node, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBookWorkBestBookPrimaryContributorEdgeBookContributorEdge) GetNode() GetBookGetBookByLegacyIdBookWorkBestBookPrimaryContributorEdgeBookContributorEdgeNodeContributor {
+	return v.Node
+}
+
+// GetBookGetBookByLegacyIdBookWorkBestBookPrimaryContributorEdgeBookContributorEdgeNodeContributor includes the requested fields of the GraphQL type Contributor.
+type GetBookGetBookByLegacyIdBookWorkBestBookPrimaryContributorEdgeBookContributorEdgeNodeContributor struct {
+	LegacyId int64 `json:"legacyId"`
+}
+
+// GetLegacyId returns GetBookGetBookByLegacyIdBookWorkBestBookPrimaryContributorEdgeBookContributorEdgeNodeContributor.LegacyId, and is useful for accessing the field via an interface.
+func (v *GetBookGetBookByLegacyIdBookWorkBestBookPrimaryContributorEdgeBookContributorEdgeNodeContributor) GetLegacyId() int64 {
+	return v.LegacyId
+}
 
 // GetBookGetBookByLegacyIdBookWorkDetails includes the requested fields of the GraphQL type WorkDetails.
 type GetBookGetBookByLegacyIdBookWorkDetails struct {
@@ -905,6 +937,12 @@ query GetBook ($legacyId: Int!) {
 				legacyId
 				title
 				titlePrimary
+				primaryContributorEdge {
+					role
+					node {
+						legacyId
+					}
+				}
 			}
 			editions {
 				edges {

--- a/gr/queries.graphql
+++ b/gr/queries.graphql
@@ -63,6 +63,12 @@ query GetBook($legacyId: Int!) {
         legacyId
         title
         titlePrimary
+        primaryContributorEdge {
+          role
+          node {
+            legacyId
+          }
+        }
       }
       editions {
         edges {

--- a/internal/gr.go
+++ b/internal/gr.go
@@ -305,7 +305,10 @@ func mapToWorkResource(book gr.BookInfo, work gr.GetBookGetBookByLegacyIdBookWor
 		workRsc.ReleaseDate = bookRsc.ReleaseDate
 	}
 
-	bookRsc.Contributors = []contributorResource{{ForeignID: author.LegacyId, Role: "Author"}}
+	bookRsc.Contributors = []contributorResource{{
+		ForeignID: work.BestBook.PrimaryContributorEdge.Node.LegacyId, // This might not match the edition's author, in which case we'll discard the edition.
+		Role:      "Author",
+	}}
 	authorRsc.Works = []workResource{workRsc}
 	workRsc.Authors = []AuthorResource{authorRsc}
 	workRsc.Books = []bookResource{bookRsc} // TODO: Add best book here as well?

--- a/internal/gr_test.go
+++ b/internal/gr_test.go
@@ -171,6 +171,11 @@ func TestGRGetBookDataIntegrity(t *testing.T) {
 						},
 						BestBook: gr.GetBookGetBookByLegacyIdBookWorkBestBook{
 							LegacyId: 6609765,
+							PrimaryContributorEdge: gr.GetBookGetBookByLegacyIdBookWorkBestBookPrimaryContributorEdgeBookContributorEdge{
+								Node: gr.GetBookGetBookByLegacyIdBookWorkBestBookPrimaryContributorEdgeBookContributorEdgeNodeContributor{
+									LegacyId: 51942,
+								},
+							},
 						},
 						Editions: gr.GetBookGetBookByLegacyIdBookWorkEditionsBooksConnection{
 							Edges: []gr.GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdge{
@@ -184,6 +189,11 @@ func TestGRGetBookDataIntegrity(t *testing.T) {
 													Name: "English",
 												},
 											},
+											PrimaryContributorEdge: gr.BookInfoPrimaryContributorEdgeBookContributorEdge{
+												Node: gr.BookInfoPrimaryContributorEdgeBookContributorEdgeNodeContributor{
+													LegacyId: 51942,
+												},
+											},
 										},
 									},
 								},
@@ -195,6 +205,11 @@ func TestGRGetBookDataIntegrity(t *testing.T) {
 											Details: gr.BookInfoDetailsBookDetails{
 												Language: gr.BookInfoDetailsBookDetailsLanguage{
 													Name: "English",
+												},
+											},
+											PrimaryContributorEdge: gr.BookInfoPrimaryContributorEdgeBookContributorEdge{
+												Node: gr.BookInfoPrimaryContributorEdgeBookContributorEdgeNodeContributor{
+													LegacyId: 51942,
 												},
 											},
 										},
@@ -211,6 +226,11 @@ func TestGRGetBookDataIntegrity(t *testing.T) {
 													Name: "English",
 												},
 											},
+											PrimaryContributorEdge: gr.BookInfoPrimaryContributorEdgeBookContributorEdge{
+												Node: gr.BookInfoPrimaryContributorEdgeBookContributorEdgeNodeContributor{
+													LegacyId: 51942,
+												},
+											},
 										},
 									},
 								},
@@ -222,6 +242,24 @@ func TestGRGetBookDataIntegrity(t *testing.T) {
 											Details: gr.BookInfoDetailsBookDetails{
 												Language: gr.BookInfoDetailsBookDetailsLanguage{
 													Name: "German",
+												},
+											},
+											PrimaryContributorEdge: gr.BookInfoPrimaryContributorEdgeBookContributorEdge{
+												Node: gr.BookInfoPrimaryContributorEdgeBookContributorEdgeNodeContributor{
+													LegacyId: 51942,
+												},
+											},
+										},
+									},
+								},
+								{
+									Node: gr.GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdgeNodeBook{
+										BookInfo: gr.BookInfo{
+											LegacyId: 6609768, // Should be excluded since the primary author doesn't match.
+											Title:    "misattributed translation",
+											PrimaryContributorEdge: gr.BookInfoPrimaryContributorEdgeBookContributorEdge{
+												Node: gr.BookInfoPrimaryContributorEdgeBookContributorEdgeNodeContributor{
+													LegacyId: 9999999999,
 												},
 											},
 										},

--- a/internal/graphql_test.go
+++ b/internal/graphql_test.go
@@ -162,6 +162,12 @@ func TestQueryBuilderMultipleQueries(t *testing.T) {
         legacyId
         title
         titlePrimary
+        primaryContributorEdge {
+          role
+          node {
+            legacyId
+          }
+        }
       }
       editions {
         edges {


### PR DESCRIPTION
This should help cut back on a lot of unnecessary fetches for large authors in particular.

It's not uncommon for an edition to belong to a work but not share the work's author (according to the "best" edition). This most commonly shows up in translations entirely attributed to the translator.

We should be able to safely ignore these. They currently just cause us to load all of the translator's other editions, which isn't helpful.