### PR TITLE
Synchronous deletes

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -53,7 +53,8 @@ jobs:
           AUTHOR_ID="${{ steps.extract_id.outputs.author_id }}"
           echo "Making DELETE request for author ID: $AUTHOR_ID"
 
-          curl -X DELETE "https://api.bookinfo.pro/author/$AUTHOR_ID"
+          curl -X DELETE "https://api.bookinfo.pro/author/$AUTHOR_ID?full=true"
+          curl -X DELETE "https://hardcover.bookinfo.pro/author/$AUTHOR_ID?full=true"
 
       - name: Comment on Issue
         if: steps.extract_id.outputs.author_id != ''

--- a/internal/memory.go
+++ b/internal/memory.go
@@ -45,6 +45,7 @@ func (c *memoryCache) Set(_ context.Context, key string, value []byte, ttl time.
 
 func (c *memoryCache) Expire(_ context.Context, key string) error {
 	c.r.Del(key)
+	c.r.Wait() // Synchronous delete.
 	return nil
 }
 


### PR DESCRIPTION
A race exists where we the refresh key might not yet be fully deleted when we re-get the same author.

The fix is to wait for the delete to be flushed.