### PR TITLE
Correctly compute author ratings

### DIFF
--- a/hardcover/generated.go
+++ b/hardcover/generated.go
@@ -2202,7 +2202,7 @@ fragment WorkInfo on books {
 		}
 	}
 	rating
-	ratings_count: reviews_count
+	ratings_count
 	... DefaultEditions
 }
 fragment DefaultEditions on books {
@@ -2351,7 +2351,7 @@ fragment WorkInfo on books {
 		}
 	}
 	rating
-	ratings_count: reviews_count
+	ratings_count
 	... DefaultEditions
 }
 fragment EditionInfo on editions {

--- a/hardcover/queries.graphql
+++ b/hardcover/queries.graphql
@@ -79,7 +79,7 @@ fragment WorkInfo on books {
     }
   }
   rating
-  ratings_count: reviews_count
+  ratings_count
   ...DefaultEditions
 }
 

--- a/internal/controller.go
+++ b/internal/controller.go
@@ -808,9 +808,14 @@ func (c *Controller) denormalizeWorks(ctx context.Context, authorID int64, workI
 		} else {
 			titles[strings.ToUpper(w.Title)]++
 		}
-		for _, b := range w.Books {
-			ratingCount += b.RatingCount
-			ratingSum += b.RatingSum
+		// HC stores rating on the work while GR is on the edition.
+		ratingCount += w.RatingCount
+		ratingSum += w.RatingSum
+		if w.RatingCount == 0 {
+			for _, b := range w.Books {
+				ratingCount += b.RatingCount
+				ratingSum += b.RatingSum
+			}
 		}
 		for _, s := range w.Series {
 			// Fetch the complete series since we might not derive it correctly from works alone.
@@ -867,6 +872,7 @@ func (c *Controller) denormalizeWorks(ctx context.Context, authorID int64, workI
 		}
 	}
 	if ratingCount != 0 {
+		author.RatingCount = ratingCount
 		author.AverageRating = float32(ratingSum) / float32(ratingCount)
 	}
 

--- a/internal/graphql_test.go
+++ b/internal/graphql_test.go
@@ -146,7 +146,7 @@ fragment WorkInfo on books {
     }
   }
   rating
-  ratings_count: reviews_count
+  ratings_count
   ...DefaultEditions
 }`, id1, id2, id2, id2, id1, id1, id2, id2, id2, id2)
 

--- a/internal/hardcover.go
+++ b/internal/hardcover.go
@@ -301,6 +301,10 @@ func mapHardcoverToWorkResource(ctx context.Context, edition hardcover.EditionIn
 		Series:       series,
 		Genres:       genres,
 		RelatedWorks: []int{},
+
+		RatingCount:   work.Ratings_count,
+		RatingSum:     int64(float64(work.Ratings_count) * work.Rating),
+		AverageRating: work.Rating,
 	}
 
 	bookRsc.Contributors = []contributorResource{{ForeignID: author.Id, Role: "Author"}}

--- a/internal/resources.go
+++ b/internal/resources.go
@@ -26,6 +26,10 @@ type workResource struct {
 	// New fields
 	KCA        string `json:"KCA"`
 	BestBookID int64  `json:"BestBookId"`
+
+	RatingCount   int64   `json:"RatingCount"`
+	AverageRating float64 `json:"AverageRating"`
+	RatingSum     int64   `json:"RatingSum"`
 }
 
 // AuthorResource collects every edition of every work by an author.


### PR DESCRIPTION
Hardcover stores ratings on the work, not the editions. 