### PR TITLE
Add reverse lookups for ASINs

### DIFF
--- a/internal/cache.go
+++ b/internal/cache.go
@@ -159,3 +159,7 @@ func AuthorKey(authorID int64) string {
 func seriesKey(seriesID int64) string {
 	return fmt.Sprintf("s%d", seriesID)
 }
+
+func asinKey(asin string) string {
+	return fmt.Sprintf("z%s", asin)
+}

--- a/internal/hardcover.go
+++ b/internal/hardcover.go
@@ -58,7 +58,6 @@ func (g *HCGetter) Search(ctx context.Context, query string) ([]SearchResource, 
 
 			bytes, _, err := g.GetWork(ctx, id, nil)
 			if err != nil {
-				Log(ctx).Warn("problem getting work for search", "workID", id, "err", err)
 				return
 			}
 

--- a/internal/resources.go
+++ b/internal/resources.go
@@ -112,3 +112,9 @@ type SearchResource struct {
 type SearchResourceAuthor struct {
 	ID int64 `json:"id"`
 }
+
+// asinResource is a new resource which maps ASINs to their corresponding
+// editions.
+type asinResource struct {
+	EditionID int64 `json:"editionId"`
+}


### PR DESCRIPTION
Hardcover search supports ISBN lookups but not ASIN, so store a reverse lookup table in the cache to help resolve these.