### PR TITLE
Dedupe search results

### DIFF
--- a/internal/hardcover.go
+++ b/internal/hardcover.go
@@ -78,7 +78,7 @@ func (g *HCGetter) Search(ctx context.Context, query string) ([]SearchResource, 
 
 			results = append(results, SearchResource{
 				BookID: workRsc.BestBookID,
-				WorkID: id,
+				WorkID: workRsc.ForeignID,
 				Author: SearchResourceAuthor{
 					ID: workRsc.Authors[0].ForeignID,
 				},


### PR DESCRIPTION
The client expects distinct book & work IDs returned by the search endpoint, and HC can sometimes return dupes.