### PR TITLE
feat: Add ALLOW_PENDING_BOOKS environment variable

### DIFF
--- a/cmd/rghc/main.go
+++ b/cmd/rghc/main.go
@@ -36,6 +36,8 @@ type server struct {
 
 	HardcoverAuth     string `required:"" env:"HARDCOVER_AUTH" xor:"hardcover-auth" help:"Hardcover Authorization header, e.g. 'Bearer ...'"`
 	HardcoverAuthFile []byte `required:"" type:"filecontent" xor:"hardcover-auth" env:"HARDCOVER_AUTH_FILE" help:"File containing the Hardcover Authorization header, e.g. 'Bearer ...'"`
+
+	AllowPendingBooks bool `default:"false" env:"ALLOW_PENDING_BOOKS" help:"Allow books in pending state in all searches."`
 }
 
 func (s *server) Run() error {
@@ -73,7 +75,7 @@ func (s *server) Run() error {
 		return err
 	}
 
-	getter, err := internal.NewHardcoverGetter(cache, gql)
+	getter, err := internal.NewHardcoverGetter(cache, gql, s.AllowPendingBooks)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Problem

Some books in Hardcover have a `state: "pending"` status, even when they are legitimate, published books. For example:

- **Book**: "Engine of Inequality" by Karen Petrou
- **ISBN**: 9781119726746 / 1119726743
- **Published**: March 2021 (4+ years ago)
- **Hardcover URL**: https://hardcover.app/books/engine-of-inequality
- **Status**: `pending`

Currently, rreading-glasses filters out all pending books to maintain search quality, but this means some legitimate books cannot be found or added.

### Solution

This PR adds an optional `ALLOW_PENDING_BOOKS` environment variable (default: `false`) that allows users to include pending books in their searches if they want to see more results.

### Configuration

Set the environment variable when running the server:

```bash
# Default behavior - filter out pending books for quality
ALLOW_PENDING_BOOKS=false ./rghc serve

# Allow all pending books in search results
ALLOW_PENDING_BOOKS=true ./rghc serve
```

### Changes

- **internal/hardcover.go** - Simplified pending book check to only respect the `allowPending` flag
- **cmd/rghc/main.go** - Added `AllowPendingBooks` config flag (already present from previous commit)

### Testing

Tested with "Engine of Inequality" (work ID: 664632):
- With `ALLOW_PENDING_BOOKS=false`: Book is filtered out (not found)
- With `ALLOW_PENDING_BOOKS=true`: Book is searchable and can be added

### Use Case

This is particularly useful for users who:
- Want access to the widest possible catalog, even if some entries are incomplete
- Are willing to manually verify book metadata
- Need to add specific books that happen to be marked as pending in Hardcover's database

---

### Future Enhancement Consideration

An alternative approach would be to automatically allow pending books only for ISBN/ASIN searches (where users are looking for a specific book), while maintaining the quality filter for general title/author searches. 

**Technical Challenge**: This approach has a fundamental limitation due to how client applications interact with the API:

1. **Search Request**: Client searches by ISBN → `GET /search?q=1119726743`
   - Context flag can be set: `ctx = context.WithValue(ctx, isbnSearchKey, true)`
   - Pending filter is bypassed, book is found and returned

2. **Follow-up Request**: Client clicks "Add" → `GET /work/664632` (separate HTTP request)
   - This is a **new HTTP request** with a fresh context - no connection to the original search
   - The `isbnSearchKey` context value from the search request doesn't exist
   - The pending filter applies, returning 404

**Why Context Can't Be Passed**:
- HTTP is stateless - each request has its own `context.Context`
- The `/work/{id}` endpoint has no way to know the work ID came from an ISBN search vs. a title search vs. a direct link
- We would need to either:
  - Add a query parameter like `/work/664632?allow_pending=true` (requires client changes)
  - Store "recently found via ISBN" state server-side (adds complexity, cache invalidation issues)
  - Modify the API contract to pass search context through the work ID (breaking change)

**Additional Complexity**: Even if we preserved context through the denormalization goroutine (which calls `GetWork` internally after `GetBook`), this only helps with the internal flow. The external client's subsequent HTTP request to `/work/{id}` would still fail because it's a completely separate request with no context.

The current implementation with a simple environment variable sidesteps these architectural challenges by providing consistent behavior across all requests when enabled.