### PR TITLE
Do not filter out books with a state of "pending" from Hardcover

### DIFF
--- a/internal/hardcover.go
+++ b/internal/hardcover.go
@@ -117,10 +117,6 @@ func (g *HCGetter) GetWork(ctx context.Context, workID int64, saveEditions editi
 		return g.GetWork(ctx, resp.Books_by_pk.Canonical_id, saveEditions)
 	}
 
-	if resp.Books_by_pk.WorkInfo.State == "pending" {
-		return nil, 0, errors.Join(errNotFound, fmt.Errorf("book is pending"))
-	}
-
 	if saveEditions != nil {
 		editions := map[editionDedupe]workResource{}
 		for _, e := range resp.Books_by_pk.Editions {


### PR DESCRIPTION
Some conversations in https://github.com/blampe/rreading-glasses/pull/455

"We don't use that for which books to show though. We use the book_status_id for that. We also hide books from search that have been added by users, but not verified (either by a librarian, or by linking it with an external book on another site)."

Based on my conversation with the Hardcover devs, it is my opinion that we should just entirely get rid of the state == pending filtering. This field is not designed to used to determine if books should be shown.

The integration already filters based on that book_status_id, so no other changes would be needed.