### PR TITLE
Docker compose container hostname fix 

### DIFF
--- a/docker-compose-gr.yml
+++ b/docker-compose-gr.yml
@@ -25,7 +25,7 @@ services:
 
   rreading-glasses-db:
     image: postgres:17
-    container_name: postgres
+    container_name: rreading-glasses-db
     restart: always
     environment:
       POSTGRES_USER: rreading-glasses


### PR DESCRIPTION
In the gr version of docker compose you are targeting the hostname of postgres with "rreading-glasses-db" but you explicitly name the container "postgres". This is a simple fix to the old problem.