### PR TITLE
Reset author when denorm finds a 404

### DIFF
--- a/internal/controller.go
+++ b/internal/controller.go
@@ -453,7 +453,7 @@ func (c *Controller) getBook(ctx context.Context, bookID int64) (ttlpair, error)
 					// refresh. This should hopefully be enough to get back to
 					// a good state.
 					Log(ctx).Warn("force refreshing author due to unexpected 404", "bookID", bookID, "authorID", authorID)
-					c.cache.Expire(ctx, AuthorKey(authorID))
+					_ = c.cache.Expire(ctx, AuthorKey(authorID))
 					_ = c.persister.Delete(ctx, authorID)
 					_, _, _ = c.GetAuthor(ctx, authorID)
 				} else {


### PR DESCRIPTION
I suspect some authors are in a bad state:
* An error might have caused us to cache a 404 for the author.
* When refreshing the cached bytes also reflect that 404.
* Denorm gives up when it finds a 404.

Instead of giving up when we see a 404, we should remove these 404 placeholders because we know an author with this ID must exist.