### PR TITLE
Throttle clients with 429

### DIFF
--- a/internal/handler.go
+++ b/internal/handler.go
@@ -91,9 +91,11 @@ func NewMux(h *Handler, reg *prometheus.Registry) http.Handler {
 	// Clients retry really aggressively and create thundering herds. Tell them
 	// to back off if we're overloaded.
 	handler := middleware.ThrottleWithOpts(middleware.ThrottleOpts{
-		Limit:        20,
-		BacklogLimit: 100,
-		RetryAfterFn: func(ctxDone bool) time.Duration {
+		Limit:          20,
+		BacklogLimit:   100,
+		BacklogTimeout: time.Minute,
+		StatusCode:     http.StatusTooManyRequests,
+		RetryAfterFn: func(_ bool) time.Duration {
 			return fuzz(30*time.Second, 10)
 		},
 	})(mux)


### PR DESCRIPTION
We have a problem right now where it's hard to bring things back up because clients constantly retry on error. This just makes things worse because we're not able to make progress fetching things with tight limits like the legacy GR API.

I think the clients respect this code and the Retry-After header. Under stable conditions we don't go above a handful of RPS so this should be generous enough.