### PR TITLE
Only throttle /author for now

### DIFF
--- a/internal/handler.go
+++ b/internal/handler.go
@@ -89,7 +89,7 @@ func NewMux(h *Handler, reg *prometheus.Registry) http.Handler {
 	}))
 
 	throttled := middleware.ThrottleWithOpts(middleware.ThrottleOpts{
-		Limit:          10,
+		Limit:          2,
 		BacklogLimit:   100,
 		BacklogTimeout: time.Minute,
 		StatusCode:     http.StatusTooManyRequests,


### PR DESCRIPTION
This is the majority of traffic, and other endpoints (e.g. search, metrics, etc.) don't play well with blanket throttling.