### PR TITLE
fix(hardcover): decode search ids as int64

### DIFF
--- a/hardcover/generated.go
+++ b/hardcover/generated.go
@@ -1865,11 +1865,11 @@ func (v *SearchResponse) GetSearch() SearchSearchSearchOutput { return v.Search 
 
 // SearchSearchSearchOutput includes the requested fields of the GraphQL type SearchOutput.
 type SearchSearchSearchOutput struct {
-	Ids []string `json:"ids"`
+	Ids []int64 `json:"ids"`
 }
 
 // GetIds returns SearchSearchSearchOutput.Ids, and is useful for accessing the field via an interface.
-func (v *SearchSearchSearchOutput) GetIds() []string { return v.Ids }
+func (v *SearchSearchSearchOutput) GetIds() []int64 { return v.Ids }
 
 // WorkInfo includes the GraphQL fields of books requested by the fragment WorkInfo.
 // The GraphQL type's documentation follows.

--- a/hardcover/schema.graphql
+++ b/hardcover/schema.graphql
@@ -503,7 +503,7 @@ type ReportOutput {
 
 type SearchOutput {
   error: String
-  ids: [String]
+  ids: [Int]
   page: Int
   per_page: Int
   query: String

--- a/internal/hardcover.go
+++ b/internal/hardcover.go
@@ -8,7 +8,6 @@ import (
 	"iter"
 	"maps"
 	"slices"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -36,7 +35,7 @@ func NewHardcoverGetter(cache cache[[]byte], gql graphql.Client) (*HCGetter, err
 // Search hits the GraphQL endpoint to fetch relevant work IDs and then fetches
 // those in order to return the necessary edition and author IDs to the client.
 func (g *HCGetter) Search(ctx context.Context, query string) ([]SearchResource, error) {
-	workIDs := []string{}
+	workIDs := []int64{}
 
 	// Try a lookup by ASIN/ISBN if the query looks like one
 	if _asin.Match([]byte(query)) || isbn.Validate(query) {
@@ -45,7 +44,7 @@ func (g *HCGetter) Search(ctx context.Context, query string) ([]SearchResource, 
 			return nil, fmt.Errorf("looking up: %w", err)
 		}
 		for _, e := range resp.Editions {
-			workIDs = append(workIDs, fmt.Sprint(e.Book_id))
+			workIDs = append(workIDs, e.Book_id)
 		}
 	} else {
 		// Otherwise do a normal search.
@@ -63,11 +62,7 @@ func (g *HCGetter) Search(ctx context.Context, query string) ([]SearchResource, 
 
 	for _, workID := range workIDs {
 		wg.Go(func() {
-			id, err := strconv.ParseInt(workID, 10, 64)
-			if err != nil {
-				Log(ctx).Warn("problem parsing", "workID", workID, "err", err)
-				return
-			}
+			id := workID
 
 			bytes, _, err := g.GetWork(ctx, id, nil)
 			if err != nil {


### PR DESCRIPTION
## Summary
Hardcover's `search` response now returns **numeric** `ids` in JSON (aligned with `int[]` in the schema). The genqlient struct used `[]string`, which caused JSON decode to fail with `Mismatch type string with value number` and **500** responses from `/search`.

## Changes
- `SearchSearchSearchOutput.Ids`: `[]string` -> `[]int64` (`hardcover/generated.go`)
- `HCGetter.Search`: carry `[]int64` work IDs; ASIN/ISBN path appends `e.Book_id` directly; remove per-ID `strconv.ParseInt`

## Context
Per a response on the Hardcover Discord (api channel), ids were typed as `int[]` but the API previously serialized them as strings; that behavior is now corrected upstream.

Fixes #548