### PR TITLE
Accept string-or-number for Hardcover search.ids (fixes #548)

### DIFF
--- a/hardcover/flexible_id.go
+++ b/hardcover/flexible_id.go
@@ -1,0 +1,37 @@
+package hardcover
+
+import (
+	"bytes"
+	"encoding/json"
+	"strconv"
+)
+
+// FlexibleID is a string that unmarshals from either a JSON string or number.
+// Hardcover's `search.ids` field has historically been [String] but the API
+// now returns numbers, so we accept both. See upstream issue #548.
+type FlexibleID string
+
+func (f *FlexibleID) UnmarshalJSON(data []byte) error {
+	data = bytes.TrimSpace(data)
+	if len(data) > 0 && data[0] == '"' {
+		var s string
+		if err := json.Unmarshal(data, &s); err != nil {
+			return err
+		}
+		*f = FlexibleID(s)
+		return nil
+	}
+	var n json.Number
+	if err := json.Unmarshal(data, &n); err != nil {
+		return err
+	}
+	*f = FlexibleID(n.String())
+	return nil
+}
+
+func (f FlexibleID) String() string { return string(f) }
+
+// Int64 parses the ID as int64.
+func (f FlexibleID) Int64() (int64, error) {
+	return strconv.ParseInt(string(f), 10, 64)
+}

--- a/hardcover/generated.go
+++ b/hardcover/generated.go
@@ -1865,11 +1865,11 @@ func (v *SearchResponse) GetSearch() SearchSearchSearchOutput { return v.Search 
 
 // SearchSearchSearchOutput includes the requested fields of the GraphQL type SearchOutput.
 type SearchSearchSearchOutput struct {
-	Ids []string `json:"ids"`
+	Ids []FlexibleID `json:"ids"`
 }
 
 // GetIds returns SearchSearchSearchOutput.Ids, and is useful for accessing the field via an interface.
-func (v *SearchSearchSearchOutput) GetIds() []string { return v.Ids }
+func (v *SearchSearchSearchOutput) GetIds() []FlexibleID { return v.Ids }
 
 // WorkInfo includes the GraphQL fields of books requested by the fragment WorkInfo.
 // The GraphQL type's documentation follows.

--- a/internal/hardcover.go
+++ b/internal/hardcover.go
@@ -53,7 +53,9 @@ func (g *HCGetter) Search(ctx context.Context, query string) ([]SearchResource, 
 		if err != nil {
 			return nil, fmt.Errorf("searching: %w", err)
 		}
-		workIDs = resp.Search.Ids
+		for _, id := range resp.Search.Ids {
+			workIDs = append(workIDs, id.String())
+		}
 	}
 
 	wg := sync.WaitGroup{}


### PR DESCRIPTION
## Summary

Hardcover's GraphQL API now returns `search.ids` as JSON numbers, but their schema still types the field as `[String]` (which our genqlient bindings honor). The result is a 500 on every `/search` call:

```
json: cannot unmarshal number into Go struct field SearchSearchSearchOutput.search.ids of type string
```

This affects both `hardcover.bookinfo.pro` and self-hosted instances. Fixes #548.

## Approach

Add a `FlexibleID` type in `hardcover/flexible_id.go` whose `UnmarshalJSON` accepts either a JSON string or a JSON number, normalizing the value to a string. Update `SearchSearchSearchOutput.Ids` to `[]FlexibleID` in the generated bindings, and adjust the consumer in `internal/hardcover.go` to call `.String()` when collecting work IDs.

Scope is intentionally narrow — only the `search.ids` field uses this. Other `ids` fields typed as `Int` in the schema continue to bind to `int64` as before. No regen of the full bindings was attempted; if you re-run `go generate`, you'll need to either update the `genqlient.yaml` binding for `String` (would be too broad) or re-apply the small generated.go diff. Happy to take this another direction if you'd prefer to push Hardcover to fix the schema instead, but the API is already returning numbers in the wild so a tolerant client seems warranted regardless.

## Test plan

- [x] Builds cleanly (`docker build`)
- [x] Deployed to a self-hosted instance backing Bookshelf (Readarr fork) — `/search` returns 200 with results instead of 500
- [ ] Existing unit tests pass — please run CI; I don't have a Hardcover-mocked test suite locally