### PR TITLE
graphql: retry batched requests on transient network errors

### DIFF
--- a/internal/graphql.go
+++ b/internal/graphql.go
@@ -5,11 +5,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"maps"
+	mathrand "math/rand/v2"
+	"net"
 	"net/http"
+	"net/url"
 	"slices"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/Khan/genqlient/graphql"
@@ -119,10 +124,12 @@ func (c *batchedgqlclient) flush(ctx context.Context) {
 	// Issue the request in a separate goroutine so we can continue to
 	// accumulate queries without needing to wait for the network call.
 	go func(batch batchedQuery) {
-		ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+		// 120s covers up to 3 attempts with 1s+2s+4s of backoff plus the
+		// per-attempt network deadline. See retryMakeRequest below.
+		ctx, cancel := context.WithTimeout(ctx, 120*time.Second)
 		defer cancel()
 
-		err := c.wrapped.MakeRequest(ctx, req, resp)
+		err := retryMakeRequest(ctx, c.wrapped, req, resp)
 
 		// Extract any field-level errors, and return them to their
 		// subscribers. We can ignore the top-level err in this case, because
@@ -224,6 +231,133 @@ type subscription struct {
 	resp  *graphql.Response
 	respC chan error
 	field string
+}
+
+// retryMakeRequest wraps graphql.Client.MakeRequest with exponential-backoff
+// retries on transient network errors (dial timeouts, connection resets, EOF,
+// context deadline). It does NOT retry on response-level errors (4xx/5xx with
+// a parsed body, or GraphQL error fields) — those are surfaced unchanged so
+// the caller can react to genuine API errors.
+//
+// A single transient upstream blip would otherwise cascade to a 500 from
+// rreading-glasses and break a downstream Readarr/Bookshelf identification
+// batch. See https://github.com/blampe/rreading-glasses/issues/<TBD>.
+// Retry parameters. Backoff sequence is baseBackoff * 2^attempt + jitter;
+// total wall time is bounded by the caller's context deadline.
+const (
+	maxRetryAttempts = 3
+	baseBackoff      = 1 * time.Second
+	jitterFraction   = 4 // jitter up to backoff/jitterFraction
+)
+
+// retryMakeRequest wraps graphql.Client.MakeRequest with exponential-backoff
+// retries on transient network errors. It does NOT retry on response-level
+// errors (4xx/5xx with a parsed body, or populated GraphQL response.Errors)
+// since those mean the upstream is alive and disagreeing with our request
+// rather than unreachable — see isTransientNetErr.
+//
+// Without this wrapper, a single transient blip (dial timeout, DNS hiccup)
+// cascades to a 500 from rreading-glasses, which breaks downstream Readarr
+// identification batches that treat any 5xx as fatal.
+func retryMakeRequest(ctx context.Context, gql graphql.Client, req *graphql.Request, resp *graphql.Response) error {
+	var err error
+	for attempt := 0; attempt < maxRetryAttempts; attempt++ {
+		err = gql.MakeRequest(ctx, req, resp)
+		if err == nil || !isTransientNetErr(err) || ctx.Err() != nil {
+			return err
+		}
+		backoff := baseBackoff << attempt // 1s, 2s, 4s
+		if jitterFraction > 0 {
+			backoff += mathrand.N(backoff / jitterFraction)
+		}
+		Log(ctx).Warn("transient upstream error, retrying",
+			"attempt", attempt+1, "max", maxRetryAttempts, "backoff", backoff, "err", err)
+		select {
+		case <-time.After(backoff):
+		case <-ctx.Done():
+			return err
+		}
+	}
+	return err
+}
+
+// isTransientNetErr reports whether err is a network-level error worth
+// retrying — timeouts, dial failures, resets, DNS hiccups, EOFs.
+//
+// It deliberately does NOT include response-level errors (HTTP 4xx/5xx with
+// a parsed body): an upstream that responds, even with an error code, is
+// alive and disagreeing with our request — the right behavior is to surface
+// that to the caller, not silently retry.
+//
+// All matchers use typed errors (errors.Is / errors.As) — no string
+// comparison — to stay stable across Go versions.
+func isTransientNetErr(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Context errors mean the caller already wants us to stop, but they're
+	// also what a per-attempt sub-context returns on timeout. The caller's
+	// own ctx.Err() check above retryMakeRequest's MakeRequest call is what
+	// actually breaks the loop on caller cancellation — here we just say
+	// "yes, this attempt's deadline being hit is transient w.r.t. the call."
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return true
+	}
+
+	// Premature EOF means the upstream connection died mid-response.
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+
+	// Socket-level errors that always represent a transient peer/network state.
+	for _, syscallErr := range []error{
+		syscall.ECONNREFUSED,
+		syscall.ECONNRESET,
+		syscall.ECONNABORTED,
+		syscall.EPIPE,
+		syscall.ETIMEDOUT,
+		syscall.EHOSTUNREACH,
+		syscall.ENETUNREACH,
+	} {
+		if errors.Is(err, syscallErr) {
+			return true
+		}
+	}
+
+	// DNS failures — retry unless the name is permanently unresolvable.
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return !dnsErr.IsNotFound
+	}
+
+	// http.Client wraps transport-level errors as *url.Error; unwrap once
+	// then recurse. (*url.Error.Timeout() also catches some cases, but
+	// recursing covers DNS / syscall errors nested inside it.)
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		if urlErr.Timeout() {
+			return true
+		}
+		if urlErr.Err != nil && urlErr.Err != err {
+			return isTransientNetErr(urlErr.Err)
+		}
+	}
+
+	// Any net.Error that reports itself as a timeout.
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+
+	// *net.OpError covers dial / read / write failures on a connection.
+	// We hit it last so we can defer to the more-specific matches above.
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return true
+	}
+
+	return false
 }
 
 // gqlStatusErr translates errors into meaningful status codes. The client

--- a/internal/retry_test.go
+++ b/internal/retry_test.go
@@ -1,0 +1,168 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/Khan/genqlient/graphql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeGQLClient lets each test script a sequence of errors-then-success.
+type fakeGQLClient struct {
+	errs    []error
+	n       atomic.Int32
+	delay   time.Duration // sleep before returning, simulates work
+	respect bool          // honor ctx cancellation in the delay
+}
+
+func (f *fakeGQLClient) MakeRequest(ctx context.Context, _ *graphql.Request, _ *graphql.Response) error {
+	if f.delay > 0 {
+		if f.respect {
+			select {
+			case <-time.After(f.delay):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		} else {
+			time.Sleep(f.delay)
+		}
+	}
+	i := f.n.Add(1) - 1
+	if int(i) >= len(f.errs) {
+		return nil
+	}
+	return f.errs[i]
+}
+
+func TestIsTransientNetErr(t *testing.T) {
+	// Synthesize the kind of error a real http.Client returns on a dial
+	// timeout: *url.Error wrapping *net.OpError wrapping a syscall.Errno.
+	wrappedDialTimeout := &url.Error{
+		Op:  "Post",
+		URL: "https://api.example/graphql",
+		Err: &net.OpError{
+			Op:  "dial",
+			Net: "tcp",
+			Err: syscall.ETIMEDOUT,
+		},
+	}
+
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"plain error", errors.New("oh no"), false},
+		{"plain wrapped error", fmt.Errorf("doing thing: %w", errors.New("oh no")), false},
+
+		// Context — caller cancellation / per-attempt deadline.
+		{"context deadline", context.DeadlineExceeded, true},
+		{"context canceled", context.Canceled, true},
+		{"wrapped context deadline", fmt.Errorf("getting: %w", context.DeadlineExceeded), true},
+
+		// Premature EOF mid-response.
+		{"io EOF", io.EOF, true},
+		{"io unexpected EOF", io.ErrUnexpectedEOF, true},
+		{"wrapped EOF", fmt.Errorf("reading: %w", io.EOF), true},
+
+		// Socket-level syscalls (typed, not stringly).
+		{"ECONNREFUSED", syscall.ECONNREFUSED, true},
+		{"ECONNRESET", syscall.ECONNRESET, true},
+		{"ECONNABORTED", syscall.ECONNABORTED, true},
+		{"EPIPE", syscall.EPIPE, true},
+		{"ETIMEDOUT", syscall.ETIMEDOUT, true},
+		{"EHOSTUNREACH", syscall.EHOSTUNREACH, true},
+		{"ENETUNREACH", syscall.ENETUNREACH, true},
+
+		// DNS — retry unless permanently unresolvable.
+		{"DNS not found", &net.DNSError{Name: "nope.invalid", IsNotFound: true}, false},
+		{"DNS timeout", &net.DNSError{Name: "foo.example", IsTimeout: true}, true},
+		{"DNS temporary", &net.DNSError{Name: "foo.example", IsTemporary: true}, true},
+		{"DNS generic", &net.DNSError{Name: "foo.example"}, true},
+
+		// http.Client wraps everything in *url.Error.
+		{"url.Error wrapping dial timeout", wrappedDialTimeout, true},
+		{"url.Error wrapping non-net", &url.Error{Op: "Post", URL: "https://x", Err: errors.New("malformed")}, false},
+
+		// net.OpError catch-all.
+		{"net.OpError dial generic", &net.OpError{Op: "dial", Err: errors.New("unreachable")}, true},
+
+		// Response-level errors — alive upstream, do NOT retry.
+		{"http 500 in message", errors.New("server returned 500 Internal Server Error"), false},
+		{"genqlient status 400", errors.New("Request failed with status code 400"), false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, isTransientNetErr(c.err))
+		})
+	}
+}
+
+func TestRetryMakeRequest_SucceedsOnFirstTry(t *testing.T) {
+	f := &fakeGQLClient{errs: nil}
+	err := retryMakeRequest(context.Background(), f, &graphql.Request{}, &graphql.Response{})
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), f.n.Load())
+}
+
+func TestRetryMakeRequest_RetriesAndSucceeds(t *testing.T) {
+	timeout := &net.OpError{Op: "dial", Err: syscall.ETIMEDOUT}
+	f := &fakeGQLClient{errs: []error{timeout, timeout}}
+	start := time.Now()
+	err := retryMakeRequest(context.Background(), f, &graphql.Request{}, &graphql.Response{})
+	elapsed := time.Since(start)
+	require.NoError(t, err)
+	assert.Equal(t, int32(3), f.n.Load())
+	// 1s + 2s = 3s of base backoff between the 3 calls; jitter adds up to
+	// (1s + 2s) / jitterFraction = 750ms extra in the worst case.
+	assert.GreaterOrEqual(t, elapsed, 3*time.Second)
+	assert.Less(t, elapsed, 4500*time.Millisecond)
+}
+
+func TestRetryMakeRequest_DoesNotRetryOnNonTransient(t *testing.T) {
+	f := &fakeGQLClient{errs: []error{errors.New("bad request body")}}
+	err := retryMakeRequest(context.Background(), f, &graphql.Request{}, &graphql.Response{})
+	require.Error(t, err)
+	assert.Equal(t, int32(1), f.n.Load()) // exactly one attempt, no retry
+}
+
+func TestRetryMakeRequest_DoesNotRetryOnDNSNotFound(t *testing.T) {
+	notFound := &net.DNSError{Name: "nope.invalid", IsNotFound: true}
+	f := &fakeGQLClient{errs: []error{notFound}}
+	err := retryMakeRequest(context.Background(), f, &graphql.Request{}, &graphql.Response{})
+	require.Error(t, err)
+	assert.Equal(t, int32(1), f.n.Load())
+}
+
+func TestRetryMakeRequest_GivesUpAfterMaxAttempts(t *testing.T) {
+	transient := syscall.ECONNREFUSED
+	f := &fakeGQLClient{errs: []error{transient, transient, transient, transient}}
+	err := retryMakeRequest(context.Background(), f, &graphql.Request{}, &graphql.Response{})
+	require.Error(t, err)
+	assert.Equal(t, int32(maxRetryAttempts), f.n.Load())
+	assert.ErrorIs(t, err, syscall.ECONNREFUSED)
+}
+
+func TestRetryMakeRequest_AbortsOnContextCancel(t *testing.T) {
+	transient := syscall.ETIMEDOUT
+	f := &fakeGQLClient{errs: []error{transient, transient, transient}}
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	err := retryMakeRequest(ctx, f, &graphql.Request{}, &graphql.Response{})
+	elapsed := time.Since(start)
+	require.Error(t, err)
+	// Should bail out well before the 1+2+4=7s of full backoff.
+	assert.Less(t, elapsed, 2*time.Second, fmt.Sprintf("aborted in %v", elapsed))
+}


### PR DESCRIPTION
## Summary

A single transient network error to the upstream GraphQL endpoint currently cascades to a hard HTTP 500 from rreading-glasses. This patch wraps the batched `MakeRequest` call with a small retry helper so transient blips (dial timeouts, DNS hiccups, connection resets, EOFs) get retried before the error reaches the caller.

## Context

Observed cascade in a self-hosted Hardcover deployment fronting a Readarr-fork install:

```
warn  batched query error  err="Post https://api.hardcover.app/v1/graphql: dial tcp 157.230.65.225:443: i/o timeout"
error GET /search?q=ramez%20naam => HTTP 500 (30.12s)
```

A single ~30s dial timeout to `api.hardcover.app` caused:

1. `internal/graphql.go` `MakeRequest` returned the raw `*net.OpError`
2. `internal/handler.go`'s `error()` defaulted to 500 because the error chain carried no `statusErr`
3. The downstream client (Readarr/Bookshelf) treats any 5xx from its metadata source as fatal and aborted its in-progress identification batch, queueing ~80 redundant RescanFolders commands behind a stuck slot

The same outage would have been invisible if the GraphQL call had been retried once.

## Approach

Single-file patch to `internal/graphql.go` plus a new test file.

- `retryMakeRequest()` — wraps `gql.MakeRequest` with exponential-backoff retry (1s, 2s, 4s base; max 3 attempts) with up to `backoff/4` jitter via `math/rand/v2` to avoid thundering-herd if many batches hit the same outage.

- `isTransientNetErr()` — typed-only error classifier (`errors.Is` / `errors.As`) over the stdlib sentinels. Covers `context.DeadlineExceeded` / `Canceled`, `io.EOF` / `io.ErrUnexpectedEOF`, `syscall.ECONNREFUSED` / `ECONNRESET` / `ECONNABORTED` / `EPIPE` / `ETIMEDOUT` / `EHOSTUNREACH` / `ENETUNREACH`, `*net.DNSError` (excluding `IsNotFound` which is permanent), `*url.Error` (recursing into its wrapped error), `net.Error.Timeout()`, and `*net.OpError` as a final catch-all. No string matching — classification stays stable across Go versions.

  Deliberately **does not** include HTTP 4xx/5xx response-level errors: an upstream that responds with an error body is alive-and-disagreeing, which should surface to the caller rather than be silently retried.

- Per-batch context budget bumped from 60s → 120s to cover up to 3 attempts plus cumulative backoff and jitter.

## Test plan

- [x] `internal/retry_test.go` covers the full classifier matrix (26 cases including each typed sentinel and key negative cases)
- [x] Retry-and-succeed test verifies the timing empirically (~3s elapsed for one retry pair)
- [x] Retry-exhaustion test confirms max 3 attempts and the original error is returned
- [x] Non-transient error returns immediately after the first attempt
- [x] DNS `IsNotFound` is correctly treated as non-transient
- [x] Context cancel aborts retry within 500ms (doesn't burn the remaining backoff budget)
- [x] `go build ./...` and `go vet ./internal/` clean
- [x] Pre-existing `internal/` test suite still passes (modulo `TestPostgresCache` which already required a live postgres on `main`)

## Notes

- Only the rreading-glasses side of the cascade is patched here; the downstream client treating 5xx as fatal is a separate concern in a different repo.
- Doesn't honor `Retry-After` on 429s, consistent with the "don't retry response-level errors" rule.