### PR TITLE
fix: /recommended returns empty/inconsistent results due to unawaited goroutines

### DIFF
--- a/internal/controller.go
+++ b/internal/controller.go
@@ -251,6 +251,7 @@ func (c *Controller) Recommendations(ctx context.Context, page int64) (Recomment
 	for _, workID := range recs.WorkIDs {
 		wg.Add(1)
 		go func() {
+			defer wg.Done()
 			_, _, err := c.GetWork(ctx, workID)
 			if err != nil {
 				return
@@ -260,6 +261,7 @@ func (c *Controller) Recommendations(ctx context.Context, page int64) (Recomment
 			workIDs = append(workIDs, workID)
 		}()
 	}
+	wg.Wait()
 	recs.WorkIDs = workIDs
 	return recs, nil
 }


### PR DESCRIPTION
## Problem

`Controller.Recommendations` (`internal/controller.go`) fetches trending work IDs, then spawns one goroutine per ID calling `GetWork` to filter out anything unresolvable. The intent is sound, but the synchronization is incomplete:

- the goroutines never call `wg.Done()`;
- the function never calls `wg.Wait()`.

So immediately after the `for` loop, `recs.WorkIDs = workIDs` runs and the function returns **while the goroutines are still starting**. `workIDs` is read before it has been populated.

Observable symptoms:

- `/recommended` almost always returns `{"workIds":[]}`;
- when some works happen to be hot in cache, a few goroutines win the race and a small, *non-deterministic* subset is returned — the result varies between identical calls;
- meanwhile `GET /work/{id}` resolves those exact same IDs instantly, confirming the data and cache are fine — the function simply doesn't wait for its own work.

Reading `workIDs` while the goroutines `append` to it under `mu` is also an unsynchronized access to the slice.

## Fix

Two lines in `Controller.Recommendations`:

- `defer wg.Done()` as the first statement of the goroutine (in `defer` form so it also fires on the early `return` of the `err != nil` branch);
- `wg.Wait()` before `recs.WorkIDs = workIDs`.

The function now blocks until every `GetWork` has completed, so it returns the full set of resolvable trending works, deterministically.

## Verification

On an instance with a warm cache, `/recommended` went from returning `{"workIds":[]}` to returning a populated, stable list of work IDs, identical across repeated calls.