### PR TITLE
fix: accept fractional Goodreads rating sums

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -199,6 +199,7 @@ golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 h1:e66Fs6Z+fZTbFBAxKfP3PALWB
 golang.org/x/exp v0.0.0-20240909161429-701f63a606c0/go.mod h1:2TbTHSBQa924w8M6Xs1QcRcFwyucIwBGpK1p2f1YFFY=
 golang.org/x/mod v0.31.0 h1:HaW9xtz0+kOcWKwli0ZXy79Ix+UW/vOfmWI5QVd2tgI=
 golang.org/x/mod v0.31.0/go.mod h1:43JraMp9cGx1Rx3AqioxrbrhNsLl2l/iNAvuBkrezpg=
+golang.org/x/mod v0.32.0 h1:9F4d3PHLljb6x//jOyokMv3eX+YDeepZSEo3mFJy93c=
 golang.org/x/mod v0.32.0/go.mod h1:SgipZ/3h2Ci89DlEtEXWUk/HteuRin+HHhN+WbNhguU=
 golang.org/x/net v0.48.0 h1:zyQRTTrjc33Lhh0fBgT/H3oZq9WuvRR5gPC70xpDiQU=
 golang.org/x/net v0.48.0/go.mod h1:+ndRgGjkh8FGtu1w1FGbEC31if4VrNVMuKTgcAAnQRY=
@@ -219,6 +220,7 @@ golang.org/x/text v0.34.0 h1:oL/Qq0Kdaqxa1KbNeMKwQq0reLCCaFtqu2eNuSeNHbk=
 golang.org/x/text v0.34.0/go.mod h1:homfLqTYRFyVYemLBFl5GgL/DWEiH5wcsQ5gSh1yziA=
 golang.org/x/tools v0.40.0 h1:yLkxfA+Qnul4cs9QA3KnlFu0lVmd8JJfoq+E41uSutA=
 golang.org/x/tools v0.40.0/go.mod h1:Ik/tzLRlbscWpqqMRjyWYDisX8bG13FrdXp3o4Sr9lc=
+golang.org/x/tools v0.41.0 h1:a9b8iMweWG+S0OBnlU36rzLp20z1Rp10w+IY2czHTQc=
 golang.org/x/tools v0.41.0/go.mod h1:XSY6eDqxVNiYgezAVqqCeihT4j1U2CCsqvH3WhQpnlg=
 google.golang.org/protobuf v1.36.8 h1:xHScyCOEuuwZEc6UtSOvPbAT4zRh0xcNRYekJwfqyMc=
 google.golang.org/protobuf v1.36.8/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXntxiD/uRU=

--- a/gr/generated.go
+++ b/gr/generated.go
@@ -208,7 +208,7 @@ func (v *BookInfoPrimaryContributorEdgeBookContributorEdgeNodeContributor) GetDe
 type BookInfoStatsBookOrWorkStats struct {
 	AverageRating float64 `json:"averageRating"`
 	RatingsCount  int64   `json:"ratingsCount"`
-	RatingsSum    int64   `json:"ratingsSum"`
+	RatingsSum    float64 `json:"ratingsSum"`
 }
 
 // GetAverageRating returns BookInfoStatsBookOrWorkStats.AverageRating, and is useful for accessing the field via an interface.
@@ -218,7 +218,7 @@ func (v *BookInfoStatsBookOrWorkStats) GetAverageRating() float64 { return v.Ave
 func (v *BookInfoStatsBookOrWorkStats) GetRatingsCount() int64 { return v.RatingsCount }
 
 // GetRatingsSum returns BookInfoStatsBookOrWorkStats.RatingsSum, and is useful for accessing the field via an interface.
-func (v *BookInfoStatsBookOrWorkStats) GetRatingsSum() int64 { return v.RatingsSum }
+func (v *BookInfoStatsBookOrWorkStats) GetRatingsSum() float64 { return v.RatingsSum }
 
 // GetAuthorWorksGetWorksByContributorContributorWorksConnection includes the requested fields of the GraphQL type ContributorWorksConnection.
 type GetAuthorWorksGetWorksByContributorContributorWorksConnection struct {

--- a/gr/schema.graphql
+++ b/gr/schema.graphql
@@ -968,7 +968,7 @@ type BookOrWorkStats {
   lastReviewAt: Float
   ratingsCount: Int
   ratingsCountDist: [Int]
-  ratingsSum: Int
+  ratingsSum: Float
   textReviewsCount: Int
   textReviewsLanguageCounts: [TextReviewLanguageCount]
 }

--- a/internal/gr.go
+++ b/internal/gr.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"iter"
 	"maps"
+	"math"
 	"net/http"
 	"slices"
 	"strings"
@@ -320,7 +321,7 @@ func mapToWorkResource(book gr.BookInfo, work gr.GetBookGetBookByLegacyIdBookWor
 		IsEbook:            book.Details.Format == "Kindle Edition", // TODO: Flush this out.
 		NumPages:           book.Details.NumPages,
 		RatingCount:        book.Stats.RatingsCount,
-		RatingSum:          book.Stats.RatingsSum,
+		RatingSum:          int64(math.Round(book.Stats.RatingsSum)),
 		AverageRating:      book.Stats.AverageRating,
 		URL:                book.WebUrl,
 		// TODO: Omitting release date is a way to essentially force R to hide

--- a/internal/gr_test.go
+++ b/internal/gr_test.go
@@ -27,6 +27,15 @@ func TestGetAuthorIntegrity(t *testing.T) {
 	// 2. load author first?
 }
 
+func TestGRBookInfoAcceptsFractionalRatingsSum(t *testing.T) {
+	var book gr.BookInfo
+
+	err := json.Unmarshal([]byte(`{"stats":{"ratingsSum":5950792.5}}`), &book)
+
+	require.NoError(t, err)
+	assert.InDelta(t, 5950792.5, book.Stats.RatingsSum, 0)
+}
+
 func TestGRGetBookDataIntegrity(t *testing.T) {
 	// The client is particularly sensitive to null values.
 	// For a given work resource, it MUST
@@ -298,7 +307,7 @@ func TestGRGetBookDataIntegrity(t *testing.T) {
 						Stats: gr.BookInfoStatsBookOrWorkStats{
 							AverageRating: 4.35,
 							RatingsCount:  156543,
-							RatingsSum:    680605,
+							RatingsSum:    680605.5,
 						},
 						TitlePrimary: "Out of My Mind",
 						WebUrl:       "https://www.gr.com/book/show/6609765-out-of-my-mind",
@@ -464,6 +473,7 @@ func TestGRGetBookDataIntegrity(t *testing.T) {
 
 		require.Len(t, work.Books, 1)
 		assert.Equal(t, int64(6609765), work.Books[0].ForeignID)
+		assert.Equal(t, int64(680606), work.Books[0].RatingSum)
 
 		assert.Equal(t, "eng", work.Books[0].Language)
 	})


### PR DESCRIPTION
Fixes #577.

Goodreads occasionally returns a fractional `BookOrWorkStats.ratingsSum`. Decode that upstream field as a float, then round it explicitly when mapping to the legacy integer resource contract.

Regression coverage verifies both JSON decoding and the rounded value emitted by the controller.
