### PR TITLE
Bound background author denormalization crawl

### DIFF
--- a/internal/controller.go
+++ b/internal/controller.go
@@ -445,7 +445,7 @@ func (c *Controller) getBook(ctx context.Context, bookID int64) (ttlpair, error)
 				Log(ctx).Warn("skipping work denorm due to error", "bookID", bookID, "workID", workID, "err", err)
 				return
 			}
-			if _, _, err := c.GetAuthor(ctx, authorID); err != nil { // Ensure fetched.
+			if _, err := c.getAuthorForDenormalization(ctx, authorID); err != nil { // Ensure fetched.
 				if errors.Is(err, errNotFound) {
 					// Something's not right -- we know this author must exist
 					// because the work belongs to it, but we have a 404
@@ -514,7 +514,7 @@ func (c *Controller) getWork(ctx context.Context, workID int64) (ttlpair, error)
 			}
 
 			if authorID > 0 {
-				_, _, _ = c.GetAuthor(ctx, authorID) // Ensure fetched.
+				_, _ = c.getAuthorForDenormalization(ctx, authorID) // Ensure fetched.
 			}
 
 			c.denormC <- edge{kind: workEdge, parentID: workID, childIDs: newSet(cachedBookIDs...)}
@@ -588,9 +588,6 @@ func (c *Controller) saveEditions(grBooks ...workResource) {
 				continue
 			}
 			authorID := w.Authors[0].ForeignID
-			if _, _, err := c.GetAuthor(ctx, authorID); err != nil { // Ensure fetched.
-				continue
-			}
 
 			if len(w.Books) == 0 {
 				Log(ctx).Warn("missing books", "workID", w.ForeignID)
@@ -634,6 +631,10 @@ func (c *Controller) saveEditions(grBooks ...workResource) {
 	}()
 }
 
+func authorRefreshNeededKey(authorID int64) string {
+	return fmt.Sprintf("author-refresh-needed-%d", authorID)
+}
+
 // getAuthor returns an AuthorResource with up to 20 works populated on first
 // load. Additional works are populated asynchronously. The previous state is
 // returned while a refresh is ongoing.
@@ -655,29 +656,26 @@ func (c *Controller) getAuthor(ctx context.Context, authorID int64) (ttlpair, er
 		if slices.Equal(cachedBytes, _missing) {
 			return ttlpair{}, errNotFound
 		}
-		return ttlpair{bytes: cachedBytes, ttl: ttl}, nil
-	}
+		if _, refreshNeeded := c.cache.Get(ctx, authorRefreshNeededKey(authorID)); !refreshNeeded {
+			return ttlpair{bytes: cachedBytes, ttl: ttl}, nil
+		}
+	} else {
+		// Cache miss. Fetch new data.
+		authorBytes, err := c.getter.GetAuthor(ctx, authorID)
+		if errors.Is(err, errNotFound) {
+			c.cache.Set(ctx, AuthorKey(authorID), _missing, _missingTTL)
+			return ttlpair{}, err
+		}
+		if err != nil {
+			Log(ctx).Warn("problem getting author", "err", err, "authorID", authorID)
+			return ttlpair{}, err
+		}
 
-	// Cache miss. Fetch new data.
-	authorBytes, err := c.getter.GetAuthor(ctx, authorID)
-	if errors.Is(err, errNotFound) {
-		c.cache.Set(ctx, AuthorKey(authorID), _missing, _missingTTL)
-		return ttlpair{}, err
-	}
-	if err != nil {
-		Log(ctx).Warn("problem getting author", "err", err, "authorID", authorID)
-		return ttlpair{}, err
-	}
-
-	ttl = fuzz(_authorTTL, 1.5)
-	c.cache.Set(ctx, AuthorKey(authorID), authorBytes, ttl)
-
-	// From here we'll prefer to use the last-known state. If this is the first
-	// time we've loaded the author we won't have previous state, so use
-	// whatever we just fetched.
-	if len(cachedBytes) == 0 {
+		ttl = fuzz(_authorTTL, 1.5)
+		c.cache.Set(ctx, AuthorKey(authorID), authorBytes, ttl)
 		cachedBytes = authorBytes
 	}
+	_ = c.cache.Delete(ctx, authorRefreshNeededKey(authorID))
 
 	// Mark the author as being refreshed by recording its last known state.
 	if err := c.persister.Persist(ctx, authorID, cachedBytes); err != nil {
@@ -689,6 +687,39 @@ func (c *Controller) getAuthor(ctx context.Context, authorID int64) (ttlpair, er
 
 	// Return the last cached value to give the refresh time to complete.
 	return ttlpair{bytes: cachedBytes, ttl: ttl}, nil
+}
+
+// getAuthorForDenormalization fetches enough author metadata to update
+// relationships without scheduling a full crawl of that author's works. The
+// marker ensures a later explicit GetAuthor call still starts that refresh.
+func (c *Controller) getAuthorForDenormalization(ctx context.Context, authorID int64) (ttlpair, error) {
+	if preRefreshBytes, ok := c.cache.Get(ctx, refreshAuthorKey(authorID)); ok {
+		if slices.Equal(preRefreshBytes, _missing) {
+			return ttlpair{}, errNotFound
+		}
+		return ttlpair{bytes: preRefreshBytes, ttl: time.Hour}, nil
+	}
+
+	if cachedBytes, ttl, ok := c.cache.GetWithTTL(ctx, AuthorKey(authorID)); ok && ttl > 0 {
+		if slices.Equal(cachedBytes, _missing) {
+			return ttlpair{}, errNotFound
+		}
+		return ttlpair{bytes: cachedBytes, ttl: ttl}, nil
+	}
+
+	authorBytes, err := c.getter.GetAuthor(ctx, authorID)
+	if errors.Is(err, errNotFound) {
+		c.cache.Set(ctx, AuthorKey(authorID), _missing, _missingTTL)
+		return ttlpair{}, err
+	}
+	if err != nil {
+		return ttlpair{}, err
+	}
+
+	ttl := fuzz(_authorTTL, 1.5)
+	c.cache.Set(ctx, AuthorKey(authorID), authorBytes, ttl)
+	c.cache.Set(ctx, authorRefreshNeededKey(authorID), []byte{1}, ttl)
+	return ttlpair{bytes: authorBytes, ttl: ttl}, nil
 }
 
 type refreshAuthor struct {
@@ -939,14 +970,15 @@ func (c *Controller) denormalizeWorks(ctx context.Context, authorID int64, workI
 		return nil
 	}
 
-	authorBytes, _, err := c.GetAuthor(ctx, authorID)
+	pair, err := c.getAuthorForDenormalization(ctx, authorID)
 	if errors.Is(err, statusErr(http.StatusTooManyRequests)) {
-		authorBytes, _, err = c.GetAuthor(ctx, authorID) // Reload if we got a cold cache.
+		pair, err = c.getAuthorForDenormalization(ctx, authorID)
 	}
 	if err != nil {
 		Log(ctx).Debug("problem loading author for denormalizeWorks", "err", err)
 		return err
 	}
+	authorBytes := pair.bytes
 
 	old := newETagWriter()
 	r := io.TeeReader(bytes.NewReader(authorBytes), old)
@@ -956,6 +988,7 @@ func (c *Controller) denormalizeWorks(ctx context.Context, authorID int64, workI
 	if err != nil {
 		Log(ctx).Debug("problem unmarshaling author", "err", err, "authorID", authorID)
 		_ = c.cache.Expire(ctx, AuthorKey(authorID))
+		_ = c.cache.Delete(ctx, authorRefreshNeededKey(authorID))
 		return err
 	}
 

--- a/internal/controller.go
+++ b/internal/controller.go
@@ -635,6 +635,10 @@ func authorRefreshNeededKey(authorID int64) string {
 	return fmt.Sprintf("author-refresh-needed-%d", authorID)
 }
 
+func authorDenormalizationKey(authorID int64) string {
+	return fmt.Sprintf("author-denormalization-%d", authorID)
+}
+
 // getAuthor returns an AuthorResource with up to 20 works populated on first
 // load. Additional works are populated asynchronously. The previous state is
 // returned while a refresh is ongoing.
@@ -693,6 +697,14 @@ func (c *Controller) getAuthor(ctx context.Context, authorID int64) (ttlpair, er
 // relationships without scheduling a full crawl of that author's works. The
 // marker ensures a later explicit GetAuthor call still starts that refresh.
 func (c *Controller) getAuthorForDenormalization(ctx context.Context, authorID int64) (ttlpair, error) {
+	p, err, _ := c.group.Do(authorDenormalizationKey(authorID), func() (any, error) {
+		return c.loadAuthorForDenormalization(ctx, authorID)
+	})
+	pair := p.(ttlpair)
+	return pair, err
+}
+
+func (c *Controller) loadAuthorForDenormalization(ctx context.Context, authorID int64) (ttlpair, error) {
 	if preRefreshBytes, ok := c.cache.Get(ctx, refreshAuthorKey(authorID)); ok {
 		if slices.Equal(preRefreshBytes, _missing) {
 			return ttlpair{}, errNotFound
@@ -714,6 +726,16 @@ func (c *Controller) getAuthorForDenormalization(ctx context.Context, authorID i
 	}
 	if err != nil {
 		return ttlpair{}, err
+	}
+
+	// A full GetAuthor may have populated the cache while this upstream request
+	// was in flight. Preserve that newer state instead of replacing it with a
+	// shallow response and incorrectly marking it as needing another refresh.
+	if cachedBytes, cachedTTL, ok := c.cache.GetWithTTL(ctx, AuthorKey(authorID)); ok && cachedTTL > 0 {
+		if slices.Equal(cachedBytes, _missing) {
+			return ttlpair{}, errNotFound
+		}
+		return ttlpair{bytes: cachedBytes, ttl: cachedTTL}, nil
 	}
 
 	ttl := fuzz(_authorTTL, 1.5)

--- a/internal/controller_crawl_test.go
+++ b/internal/controller_crawl_test.go
@@ -1,8 +1,10 @@
 package internal
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"iter"
 	"testing"
 
 	"go.uber.org/mock/gomock"
@@ -40,6 +42,74 @@ func TestDenormalizeWorksDoesNotRefreshDiscoveredAuthor(t *testing.T) {
 
 	if err := controller.denormalizeWorks(ctx, authorID, workID); err != nil {
 		t.Fatalf("denormalizeWorks() error = %v", err)
+	}
+	waitForDenorm(controller)
+}
+
+func TestShallowAuthorFetchDoesNotOverwriteExplicitRefresh(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	authorID := int64(123)
+	shallowBytes, err := json.Marshal(AuthorResource{ForeignID: authorID, Name: "shallow"})
+	if err != nil {
+		t.Fatalf("json.Marshal(shallow author) error = %v", err)
+	}
+	explicitBytes, err := json.Marshal(AuthorResource{ForeignID: authorID, Name: "explicit"})
+	if err != nil {
+		t.Fatalf("json.Marshal(explicit author) error = %v", err)
+	}
+
+	shallowStarted := make(chan struct{})
+	releaseShallow := make(chan struct{})
+	getter := NewMockgetter(gomock.NewController(t))
+	first := getter.EXPECT().GetAuthor(gomock.Any(), authorID).DoAndReturn(func(context.Context, int64) ([]byte, error) {
+		close(shallowStarted)
+		<-releaseShallow
+		return shallowBytes, nil
+	})
+	getter.EXPECT().GetAuthor(gomock.Any(), authorID).After(first.Call).Return(explicitBytes, nil)
+	getter.EXPECT().GetAuthorBooks(gomock.Any(), authorID).Return(iter.Seq[int64](func(func(int64) bool) {}))
+
+	controller, err := NewController(newMemoryCache(), getter, nil, nil)
+	if err != nil {
+		t.Fatalf("NewController() error = %v", err)
+	}
+	go controller.Run(ctx)
+	t.Cleanup(func() { controller.Shutdown(ctx) })
+
+	shallowResult := make(chan ttlpair, 1)
+	shallowErr := make(chan error, 1)
+	go func() {
+		pair, err := controller.getAuthorForDenormalization(ctx, authorID)
+		shallowResult <- pair
+		shallowErr <- err
+	}()
+	<-shallowStarted
+
+	gotExplicit, _, err := controller.GetAuthor(ctx, authorID)
+	if err != nil {
+		t.Fatalf("GetAuthor() error = %v", err)
+	}
+	if !bytes.Equal(gotExplicit, explicitBytes) {
+		t.Fatalf("GetAuthor() bytes = %q, want %q", gotExplicit, explicitBytes)
+	}
+
+	close(releaseShallow)
+	pair := <-shallowResult
+	if err := <-shallowErr; err != nil {
+		t.Fatalf("getAuthorForDenormalization() error = %v", err)
+	}
+	if !bytes.Equal(pair.bytes, explicitBytes) {
+		t.Fatalf("shallow result = %q, want explicit result %q", pair.bytes, explicitBytes)
+	}
+
+	cachedBytes, ok := controller.cache.Get(ctx, AuthorKey(authorID))
+	if !ok || !bytes.Equal(cachedBytes, explicitBytes) {
+		t.Fatalf("cached author = %q, %t; want explicit result %q", cachedBytes, ok, explicitBytes)
+	}
+	if _, ok := controller.cache.Get(ctx, authorRefreshNeededKey(authorID)); ok {
+		t.Fatal("shallow refresh marker was left behind")
 	}
 	waitForDenorm(controller)
 }

--- a/internal/controller_crawl_test.go
+++ b/internal/controller_crawl_test.go
@@ -1,0 +1,45 @@
+package internal
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+)
+
+func TestDenormalizeWorksDoesNotRefreshDiscoveredAuthor(t *testing.T) {
+	t.Parallel()
+
+	getter := NewMockgetter(gomock.NewController(t))
+	controller, err := NewController(newMemoryCache(), getter, nil, nil)
+	if err != nil {
+		t.Fatalf("NewController() error = %v", err)
+	}
+
+	ctx := context.Background()
+	authorID := int64(123)
+	workID := int64(456)
+	authorBytes, err := json.Marshal(AuthorResource{ForeignID: authorID})
+	if err != nil {
+		t.Fatalf("json.Marshal(author) error = %v", err)
+	}
+	workBytes, err := json.Marshal(workResource{
+		ForeignID: workID,
+		Books:     []bookResource{{ForeignID: 789}},
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal(work) error = %v", err)
+	}
+
+	getter.EXPECT().GetAuthor(gomock.Any(), authorID).Return(authorBytes, nil)
+	getter.EXPECT().GetWork(gomock.Any(), workID, nil).Return(workBytes, authorID, nil)
+
+	go controller.Run(ctx)
+	t.Cleanup(func() { controller.Shutdown(ctx) })
+
+	if err := controller.denormalizeWorks(ctx, authorID, workID); err != nil {
+		t.Fatalf("denormalizeWorks() error = %v", err)
+	}
+	waitForDenorm(controller)
+}

--- a/internal/controller_test.go
+++ b/internal/controller_test.go
@@ -479,6 +479,7 @@ func TestMergedWorks(t *testing.T) {
 	// The author shouldn't have a duplicated work.
 	authorBytes, _, err = ctrl.GetAuthor(ctx, authorID)
 	require.NoError(t, err)
+	waitForDenorm(ctrl)
 
 	var author AuthorResource
 	require.NoError(t, json.Unmarshal(authorBytes, &author))


### PR DESCRIPTION
## Summary

- separate shallow author metadata loads used by denormalization from client-requested full author refreshes
- mark shallow cache entries so a later explicit `GetAuthor` still schedules the complete author refresh
- coordinate shallow loads with a dedicated singleflight key
- preserve newer explicit-refresh data when a shallow upstream request finishes later
- stop bulk edition discovery from eagerly fetching every discovered author
- add regression coverage for both recursive crawling and the shallow/explicit fetch race

This addresses the unbounded transitive crawl reported in #580: internal work/edition denormalization may still fetch the author metadata needed to maintain relationships, but it no longer schedules `GetAuthorBooks` for every newly discovered coauthor.

## Validation

- `go test -race ./internal -run 'Test(DenormalizeWorksDoesNotRefreshDiscoveredAuthor|ShallowAuthorFetchDoesNotOverwriteExplicitRefresh|DenormalizeMissing|Subtitles|MergedWorks)$'`
- `go test -race ./internal -skip 'Test(Postgres.*|Persister|StaleData)$'`
- `go test ./... -run '^$'`
- `go vet ./...`

The PostgreSQL integration tests were skipped because no local PostgreSQL test service was available.
