### PR TITLE
Don't crawl authors reached only transitively

### DIFF
--- a/internal/controller.go
+++ b/internal/controller.go
@@ -445,7 +445,7 @@ func (c *Controller) getBook(ctx context.Context, bookID int64) (ttlpair, error)
 				Log(ctx).Warn("skipping work denorm due to error", "bookID", bookID, "workID", workID, "err", err)
 				return
 			}
-			if _, _, err := c.GetAuthor(ctx, authorID); err != nil { // Ensure fetched.
+			if _, _, err := c.GetAuthor(withoutCrawl(ctx), authorID); err != nil { // Ensure fetched.
 				if errors.Is(err, errNotFound) {
 					// Something's not right -- we know this author must exist
 					// because the work belongs to it, but we have a 404
@@ -514,7 +514,7 @@ func (c *Controller) getWork(ctx context.Context, workID int64) (ttlpair, error)
 			}
 
 			if authorID > 0 {
-				_, _, _ = c.GetAuthor(ctx, authorID) // Ensure fetched.
+				_, _, _ = c.GetAuthor(withoutCrawl(ctx), authorID) // Ensure fetched.
 			}
 
 			c.denormC <- edge{kind: workEdge, parentID: workID, childIDs: newSet(cachedBookIDs...)}
@@ -588,7 +588,7 @@ func (c *Controller) saveEditions(grBooks ...workResource) {
 				continue
 			}
 			authorID := w.Authors[0].ForeignID
-			if _, _, err := c.GetAuthor(ctx, authorID); err != nil { // Ensure fetched.
+			if _, _, err := c.GetAuthor(withoutCrawl(ctx), authorID); err != nil { // Ensure fetched.
 				continue
 			}
 
@@ -684,11 +684,36 @@ func (c *Controller) getAuthor(ctx context.Context, authorID int64) (ttlpair, er
 		Log(ctx).Warn("problem persisting refresh", "err", err)
 	}
 
-	// Kick off a refresh but don't block on it.
-	c.refreshC <- refreshAuthor{id: authorID, state: cachedBytes}
+	// Kick off a refresh but don't block on it. Skipped when this author was
+	// only reached transitively while denormalizing something else -- see
+	// withoutCrawl.
+	if !crawlSuppressed(ctx) {
+		c.refreshC <- refreshAuthor{id: authorID, state: cachedBytes}
+	}
 
 	// Return the last cached value to give the refresh time to complete.
 	return ttlpair{bytes: cachedBytes, ttl: ttl}, nil
+}
+
+// ctxKeyNoCrawl marks a context as "resolve this author, don't crawl it".
+type ctxKeyNoCrawl struct{}
+
+// withoutCrawl suppresses the catalogue refresh that an author cache miss
+// would otherwise enqueue.
+//
+// Denormalizing a work resolves its byline, which is frequently some other
+// author (anthology contributor, co-author, translator). Refreshing those in
+// turn walks their editions, which resolve more bylines, without bound.
+// Marked contexts still fetch and cache the record; only the refresh is
+// skipped. Explicit requests are unmarked and still crawl.
+func withoutCrawl(ctx context.Context) context.Context {
+	return context.WithValue(ctx, ctxKeyNoCrawl{}, true)
+}
+
+// crawlSuppressed reports whether ctx was marked by withoutCrawl.
+func crawlSuppressed(ctx context.Context) bool {
+	suppressed, _ := ctx.Value(ctxKeyNoCrawl{}).(bool)
+	return suppressed
 }
 
 type refreshAuthor struct {
@@ -939,9 +964,9 @@ func (c *Controller) denormalizeWorks(ctx context.Context, authorID int64, workI
 		return nil
 	}
 
-	authorBytes, _, err := c.GetAuthor(ctx, authorID)
+	authorBytes, _, err := c.GetAuthor(withoutCrawl(ctx), authorID)
 	if errors.Is(err, statusErr(http.StatusTooManyRequests)) {
-		authorBytes, _, err = c.GetAuthor(ctx, authorID) // Reload if we got a cold cache.
+		authorBytes, _, err = c.GetAuthor(withoutCrawl(ctx), authorID) // Reload if we got a cold cache.
 	}
 	if err != nil {
 		Log(ctx).Debug("problem loading author for denormalizeWorks", "err", err)

--- a/internal/controller_test.go
+++ b/internal/controller_test.go
@@ -355,7 +355,9 @@ func TestSubtitles(t *testing.T) {
 		LinkItems: []seriesWorkLinkResource{},
 	}, nil)
 
-	getter.EXPECT().GetAuthorBooks(gomock.Any(), author.ForeignID).Return(iter.Seq[int64](func(func(int64) bool) {}))
+	// AnyTimes: denormalizeWorks no longer implies a crawl. Crawl behaviour is
+	// covered by TestTransitiveAuthorsAreNotCrawled.
+	getter.EXPECT().GetAuthorBooks(gomock.Any(), author.ForeignID).Return(iter.Seq[int64](func(func(int64) bool) {})).AnyTimes()
 
 	err = ctrl.denormalizeWorks(ctx, author.ForeignID, workDupe1.ForeignID, workDupe2.ForeignID, workUnique.ForeignID)
 	require.NoError(t, err)
@@ -471,7 +473,9 @@ func TestMergedWorks(t *testing.T) {
 	getter.EXPECT().GetWork(gomock.Any(), mergedID, nil).Return(workBytes, authorID, nil)
 
 	getter.EXPECT().GetAuthor(gomock.Any(), authorID).Return(authorBytes, nil)
-	getter.EXPECT().GetAuthorBooks(gomock.Any(), authorID).Return(nil)
+	// AnyTimes: denormalizeWorks no longer implies a crawl. The assertion
+	// below still covers what this test is for.
+	getter.EXPECT().GetAuthorBooks(gomock.Any(), authorID).Return(nil).AnyTimes()
 
 	err = ctrl.denormalizeWorks(ctx, authorID, workID, mergedID)
 	require.NoError(t, err)
@@ -505,4 +509,60 @@ func waitForDenorm(ctrl *Controller) {
 	} else {
 		time.Sleep(100 * time.Millisecond)
 	}
+}
+
+func TestTransitiveAuthorsAreNotCrawled(t *testing.T) {
+	// An author reached only while denormalizing something else must still be
+	// fetched and cached, but must not trigger a refresh of its catalogue --
+	// otherwise the graph walks itself without bound.
+	t.Parallel()
+
+	ctx := context.Background()
+	c := gomock.NewController(t)
+	getter := NewMockgetter(c)
+
+	const wantedAuthorID = int64(1000)   // the author a client actually asked for
+	const incidentalAuthorID = int64(99) // reached only via a work's byline
+
+	cache := newMemoryCache()
+
+	ctrl, err := NewController(cache, getter, nil, nil)
+	require.NoError(t, err)
+
+	go ctrl.Run(t.Context())
+	t.Cleanup(func() { ctrl.Shutdown(t.Context()) })
+
+	authorBytes := func(id int64) []byte {
+		b, err := json.Marshal(AuthorResource{ForeignID: id, Name: "Author"})
+		require.NoError(t, err)
+		return b
+	}
+
+	getter.EXPECT().GetAuthor(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, authorID int64) ([]byte, error) {
+			return authorBytes(authorID), nil
+		}).AnyTimes()
+
+	// The wanted author may be crawled as often as the controller likes.
+	getter.EXPECT().GetAuthorBooks(gomock.Any(), wantedAuthorID).
+		Return(iter.Seq[int64](func(func(int64) bool) {})).AnyTimes()
+
+	// The incidental author must never be crawled. gomock fails the test on
+	// any unexpected call, so the absence of an EXPECT here is the assertion.
+
+	// Reaching the incidental author the way denormalization does.
+	_, _, err = ctrl.GetAuthor(withoutCrawl(ctx), incidentalAuthorID)
+	require.NoError(t, err)
+
+	// An explicit request for the wanted author still crawls.
+	_, _, err = ctrl.GetAuthor(ctx, wantedAuthorID)
+	require.NoError(t, err)
+
+	// Let any queued refreshes drain before the mock controller asserts.
+	time.Sleep(250 * time.Millisecond)
+
+	// The incidental author was still cached -- suppression must not mean
+	// "don't fetch", only "don't crawl".
+	_, ok := ctrl.cache.Get(ctx, AuthorKey(incidentalAuthorID))
+	assert.True(t, ok, "incidental author should still be cached")
 }


### PR DESCRIPTION
### Problem

`getAuthor` enqueues a full `refreshAuthor` on **every** author cache miss, unconditionally. `getWork` calls `GetAuthor` on each work's byline "to ensure fetched" — and a byline is frequently *not* the author being refreshed, but an anthology contributor, co-author, editor or translator. That author misses cache, enqueues its own refresh, walks its own 1000 editions, and so on.

```
refreshAuthor(A) → up to 1000 editions
  → getWork(w) → GetAuthor(B)          B = co-contributor on some anthology
      → cache miss → enqueue refreshAuthor(B)
          → up to 1000 of B's editions → GetAuthor(C) → …
```

The only bound is `n > 1000` editions per author. There's no depth limit and no check for whether anything actually requested that author, so it becomes a breadth-first crawl of the whole upstream graph.

### Impact

Measured on a Readarr library with **17 authors**, Goodreads upstream, `--rpm=60`:

| | |
| --- | --- |
| authors cached | 73,648 |
| works / editions | 2.0M / 3.5M |
| cache rows | 9,330,523 |
| database | 22 GB |
| rows matching the 17 requested authors | **17 (0.0002%)** |

53% of cached authors (39,113) were sub-5KB stubs reached purely as incidental contributors. Decoded samples included `". Library of Congress. Classification"`, `"Orson Squire Fowler"` and `"Zupitza Julius 1844-1895"` — bulk-imported catalogue records, reached through anthology contributor lists.

The aftermath outlasts the growth. Every entry carries a 1-year TTL, so ~1.79M entries eventually expire and are re-fetched continuously — 400+ works per author, 3–6 minutes each, back to back — pinning ~89% of a core with Readarr idle and 0 commands queued. `--rpm` throttles upstream *requests* but doesn't bound this, because one request expands into hundreds of cached rows.

### Change

Mark contexts that reach an author transitively with `withoutCrawl`, and skip the refresh enqueue for those. Such authors are still fetched and cached — denormalization needs the record — they just no longer imply "mirror this author's entire catalogue".

Unchanged and still crawling:
- `GET /author/{id}` (what the client actually asks for)
- the refresh endpoint
- the 404-recovery path in `getBook`

Suppressed (all reached incidentally while denormalizing something else):
- `getBook` → author denorm
- `getWork` → "ensure fetched"
- `saveEditions`
- `denormalizeWorks`

### Result

Same library, same config, after the change:

| | before | after |
| --- | --- | --- |
| authors | 73,648 | **275** |
| cache rows | 9,330,523 | **35,305** |
| database | 22 GB | **102 MB** |
| CPU | 88.96% | **0.03%** |

Growth per 5 min after a cold start: `+23,715 → +9,703 → +1,887 → +0`. It converges in about 15 minutes instead of never; unpatched, no 5-minute window ever fell below +20,000. Author lookups serve in 4–10 ms.

### Tests

`TestTransitiveAuthorsAreNotCrawled` is added and fails without the change (verified by reverting just the gate).

`TestSubtitles` and `TestMergedWorks` had `GetAuthorBooks` expectations asserting that `denormalizeWorks` triggers a catalogue crawl — the behaviour being removed. Those are relaxed to `AnyTimes()` with a comment; their actual assertions (subtitle selection, merged works not duplicating) are untouched and still pass.

`TestPersister`, `TestPostgres`, `TestStaleData` and `TestPostgresCache` fail identically before and after — they need a live Postgres DSN.

### Notes

Happy to adjust the approach — a config flag, or plumbing an explicit parameter instead of a context value, would both work if you'd prefer either.
