### PR TITLE
fix(gr): accept fractional ratingsSum

### DIFF
--- a/gr/generated.go
+++ b/gr/generated.go
@@ -208,7 +208,7 @@ func (v *BookInfoPrimaryContributorEdgeBookContributorEdgeNodeContributor) GetDe
 type BookInfoStatsBookOrWorkStats struct {
 	AverageRating float64 `json:"averageRating"`
 	RatingsCount  int64   `json:"ratingsCount"`
-	RatingsSum    int64   `json:"ratingsSum"`
+	RatingsSum    float64 `json:"ratingsSum"`
 }
 
 // GetAverageRating returns BookInfoStatsBookOrWorkStats.AverageRating, and is useful for accessing the field via an interface.
@@ -218,7 +218,7 @@ func (v *BookInfoStatsBookOrWorkStats) GetAverageRating() float64 { return v.Ave
 func (v *BookInfoStatsBookOrWorkStats) GetRatingsCount() int64 { return v.RatingsCount }
 
 // GetRatingsSum returns BookInfoStatsBookOrWorkStats.RatingsSum, and is useful for accessing the field via an interface.
-func (v *BookInfoStatsBookOrWorkStats) GetRatingsSum() int64 { return v.RatingsSum }
+func (v *BookInfoStatsBookOrWorkStats) GetRatingsSum() float64 { return v.RatingsSum }
 
 // GetAuthorWorksGetWorksByContributorContributorWorksConnection includes the requested fields of the GraphQL type ContributorWorksConnection.
 type GetAuthorWorksGetWorksByContributorContributorWorksConnection struct {

--- a/gr/schema.graphql
+++ b/gr/schema.graphql
@@ -968,7 +968,7 @@ type BookOrWorkStats {
   lastReviewAt: Float
   ratingsCount: Int
   ratingsCountDist: [Int]
-  ratingsSum: Int
+  ratingsSum: Float
   textReviewsCount: Int
   textReviewsLanguageCounts: [TextReviewLanguageCount]
 }

--- a/internal/gr.go
+++ b/internal/gr.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"iter"
 	"maps"
+	"math"
 	"net/http"
 	"slices"
 	"strings"
@@ -320,7 +321,7 @@ func mapToWorkResource(book gr.BookInfo, work gr.GetBookGetBookByLegacyIdBookWor
 		IsEbook:            book.Details.Format == "Kindle Edition", // TODO: Flush this out.
 		NumPages:           book.Details.NumPages,
 		RatingCount:        book.Stats.RatingsCount,
-		RatingSum:          book.Stats.RatingsSum,
+		RatingSum:          int64(math.Round(book.Stats.RatingsSum)),
 		AverageRating:      book.Stats.AverageRating,
 		URL:                book.WebUrl,
 		// TODO: Omitting release date is a way to essentially force R to hide

--- a/internal/gr_test.go
+++ b/internal/gr_test.go
@@ -27,6 +27,16 @@ func TestGetAuthorIntegrity(t *testing.T) {
 	// 2. load author first?
 }
 
+// Goodreads sometimes reports a fractional ratingsSum -- 2423581.75 for book
+// 238226942, for example. It's an Int in the schema we generate from, so
+// decoding used to fail and take the whole book down with it.
+func TestGRFractionalRatingsSum(t *testing.T) {
+	var book gr.BookInfo
+
+	require.NoError(t, json.Unmarshal([]byte(`{"stats":{"ratingsSum":2423581.75}}`), &book))
+	assert.Equal(t, 2423581.75, book.Stats.RatingsSum)
+}
+
 func TestGRGetBookDataIntegrity(t *testing.T) {
 	// The client is particularly sensitive to null values.
 	// For a given work resource, it MUST
@@ -298,7 +308,7 @@ func TestGRGetBookDataIntegrity(t *testing.T) {
 						Stats: gr.BookInfoStatsBookOrWorkStats{
 							AverageRating: 4.35,
 							RatingsCount:  156543,
-							RatingsSum:    680605,
+							RatingsSum:    680605.75,
 						},
 						TitlePrimary: "Out of My Mind",
 						WebUrl:       "https://www.gr.com/book/show/6609765-out-of-my-mind",
@@ -464,6 +474,7 @@ func TestGRGetBookDataIntegrity(t *testing.T) {
 
 		require.Len(t, work.Books, 1)
 		assert.Equal(t, int64(6609765), work.Books[0].ForeignID)
+		assert.Equal(t, int64(680606), work.Books[0].RatingSum)
 
 		assert.Equal(t, "eng", work.Books[0].Language)
 	})


### PR DESCRIPTION
Fixes #577
Fixes #579
Fixes #581

Goodreads returns a non-integer `ratingsSum` for some works. `BookOrWorkStats.ratingsSum` is an `Int` in `gr/schema.graphql`, so genqlient types it as `int64` and decoding blows up:

```
json: cannot unmarshal number 2423581.75 into Go struct field
GetBookGetBookByLegacyIdBookWorkEditionsBooksConnectionEdgesBooksEdge.GetBookGetBookByLegacyIdBook.work.editions.edges.node.stats.ratingsSum of type int64
```

It happens while decoding `work.editions`, so one bad edition fails the entire book request. Nothing is surfaced to the client, which just sees the book never appear.

Values reported so far: `1102680.5`, `3403581.5`, `4539785.25`, `7016158.5`, `7117144.75`, and `2423581.75` (book 238226942), so it isn't a one-off. The shared `api.bookinfo.pro` instance is affected too, not just self-hosted ones.

The fix types the field as `Float` and rounds when mapping onto the legacy int64 `RatingSum` the client contract expects. `gr/generated.go` is regenerated rather than hand-edited.

This is the same approach as #578, which its author closed a couple of minutes after opening. One difference: `go.mod` and `go.sum` are byte-identical to main here. `go generate` can't run without x/tools and x/mod entries the module doesn't otherwise carry, so I added them, regenerated, and reverted both files back to their committed state, leaving the diff at the four files that matter.

`BookList.ratingsSum` is also `Int`, but no query in `queries.graphql` selects it, so I left it alone.

### Testing

`go test -count=1 -race ./...` passes with a local Postgres up. The new `TestGRFractionalRatingsSum` fails on main with exactly the error above, and the `TestGRGetBookDataIntegrity` fixture now carries a fractional sum so the rounding is covered end to end.